### PR TITLE
feat(#3): User abilities framework

### DIFF
--- a/backend/alembic/versions/0007_user_abilities.py
+++ b/backend/alembic/versions/0007_user_abilities.py
@@ -1,0 +1,71 @@
+"""Add is_admin to users; create abilities and user_abilities tables; seed demo admins
+
+Revision ID: 0007_user_abilities
+Revises: e4144dcdb2c8
+Create Date: 2026-04-26
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision = "0007_user_abilities"
+down_revision = "e4144dcdb2c8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- is_admin on users ---
+    op.add_column(
+        "users",
+        sa.Column("is_admin", sa.Boolean(), server_default="false", nullable=False),
+    )
+
+    # --- abilities lookup table ---
+    op.create_table(
+        "abilities",
+        sa.Column("key", sa.String(128), primary_key=True),
+        sa.Column("description", sa.String(512), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+
+    # --- user_abilities join table ---
+    op.create_table(
+        "user_abilities",
+        sa.Column("user_id", UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("ability_key", sa.String(128), sa.ForeignKey("abilities.key", ondelete="CASCADE"), primary_key=True),
+        sa.Column(
+            "granted_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+
+    # --- Seed: promote demo users to admin ---
+    op.execute(
+        sa.text("UPDATE users SET is_admin = TRUE WHERE email IN ('david', 'nate', 'jun')")
+    )
+
+    # --- Seed: first example ability definition ---
+    op.execute(
+        sa.text(
+            "INSERT INTO abilities (key, description) VALUES "
+            "('manage_ingredients', 'Create, update, and delete global ingredients')"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_abilities")
+    op.drop_table("abilities")
+    op.drop_column("users", "is_admin")

--- a/backend/src/formulation_ai/app.py
+++ b/backend/src/formulation_ai/app.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from formulation_ai.config import settings
+from formulation_ai.routers import admin as admin_router
 from formulation_ai.routers import auth as auth_router
 from formulation_ai.routers import ingredients as ingredients_router
 from formulation_ai.routers import projects as projects_router
@@ -27,6 +28,7 @@ def create_app() -> FastAPI:
     )
 
     app.include_router(auth_router.router)
+    app.include_router(admin_router.router)
     app.include_router(ingredients_router.router)
     app.include_router(projects_router.router)
 

--- a/backend/src/formulation_ai/auth.py
+++ b/backend/src/formulation_ai/auth.py
@@ -61,6 +61,12 @@ def get_current_user(
     return user
 
 
+def get_current_admin(current_user: User = Depends(get_current_user)) -> User:
+    if not current_user.is_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+    return current_user
+
+
 def authenticate(db: Session, email: str, password: str) -> User | None:
     user = db.query(User).filter(User.email == email).first()
     if not user or not user.password_hash:

--- a/backend/src/formulation_ai/models/__init__.py
+++ b/backend/src/formulation_ai/models/__init__.py
@@ -1,3 +1,4 @@
+from formulation_ai.models.ability import Ability
 from formulation_ai.models.base import Base
 from formulation_ai.models.formulation import Formulation, FormulationKind
 from formulation_ai.models.ingredient import FormulationIngredient, Ingredient, ProjectIngredient
@@ -6,10 +7,13 @@ from formulation_ai.models.output_property import FormulationProperty, OutputPro
 from formulation_ai.models.portfolio import Portfolio
 from formulation_ai.models.project import Project, ProjectStatus
 from formulation_ai.models.user import User
+from formulation_ai.models.user_ability import UserAbility
 
 __all__ = [
     "Base",
     "User",
+    "Ability",
+    "UserAbility",
     "Portfolio",
     "Project",
     "ProjectStatus",

--- a/backend/src/formulation_ai/models/ability.py
+++ b/backend/src/formulation_ai/models/ability.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from formulation_ai.models.base import Base
+
+
+class Ability(Base):
+    __tablename__ = "abilities"
+
+    key: Mapped[str] = mapped_column(String(128), primary_key=True)
+    description: Mapped[str | None] = mapped_column(String(512))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    user_abilities: Mapped[list[UserAbility]] = relationship(  # noqa: F821
+        back_populates="ability", cascade="all, delete-orphan"
+    )

--- a/backend/src/formulation_ai/models/user.py
+++ b/backend/src/formulation_ai/models/user.py
@@ -2,7 +2,7 @@ import uuid
 
 from sqlalchemy import Boolean, String
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from formulation_ai.models.base import Base, TimestampMixin
 
@@ -17,3 +17,14 @@ class User(Base, TimestampMixin):
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     full_name: Mapped[str | None] = mapped_column(String(256))
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    is_admin: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
+
+    user_abilities: Mapped[list["UserAbility"]] = relationship(  # noqa: F821
+        back_populates="user", cascade="all, delete-orphan", lazy="select"
+    )
+
+    @property
+    def abilities(self) -> list[str]:
+        return [ua.ability_key for ua in self.user_abilities]

--- a/backend/src/formulation_ai/models/user_ability.py
+++ b/backend/src/formulation_ai/models/user_ability.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from formulation_ai.models.base import Base
+
+
+class UserAbility(Base):
+    __tablename__ = "user_abilities"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    ability_key: Mapped[str] = mapped_column(
+        String(128), ForeignKey("abilities.key", ondelete="CASCADE"), primary_key=True
+    )
+    granted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship(back_populates="user_abilities")  # noqa: F821
+    ability: Mapped[Ability] = relationship(back_populates="user_abilities")  # noqa: F821

--- a/backend/src/formulation_ai/routers/admin.py
+++ b/backend/src/formulation_ai/routers/admin.py
@@ -1,0 +1,115 @@
+"""Admin router — user/ability management. All routes require is_admin."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session
+
+from formulation_ai.auth import get_current_admin
+from formulation_ai.db import get_db
+from formulation_ai.models import Ability, User, UserAbility
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas (local — admin-only, no need to share with other modules)
+# ---------------------------------------------------------------------------
+
+class AbilityOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    key: str
+    description: str | None
+
+
+class AbilityCreate(BaseModel):
+    key: str
+    description: str | None = None
+
+
+class UserWithAbilities(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    email: str
+    full_name: str | None
+    is_active: bool
+    is_admin: bool
+    abilities: list[str] = []
+
+
+# ---------------------------------------------------------------------------
+# Ability endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/abilities", response_model=list[AbilityOut])
+def list_abilities(
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> list[Ability]:
+    return db.query(Ability).order_by(Ability.key).all()
+
+
+@router.post("/abilities", response_model=AbilityOut, status_code=status.HTTP_201_CREATED)
+def create_ability(
+    payload: AbilityCreate,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> Ability:
+    if db.get(Ability, payload.key):
+        raise HTTPException(status_code=400, detail=f"Ability '{payload.key}' already exists")
+    ability = Ability(key=payload.key, description=payload.description)
+    db.add(ability)
+    db.commit()
+    db.refresh(ability)
+    return ability
+
+
+# ---------------------------------------------------------------------------
+# User × ability endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/users", response_model=list[UserWithAbilities])
+def list_users(
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> list[User]:
+    return db.query(User).order_by(User.email).all()
+
+
+@router.post(
+    "/users/{user_id}/abilities/{ability_key}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def grant_ability(
+    user_id: uuid.UUID,
+    ability_key: str,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> None:
+    if not db.get(User, user_id):
+        raise HTTPException(status_code=404, detail="User not found")
+    if not db.get(Ability, ability_key):
+        raise HTTPException(status_code=404, detail="Ability not found")
+    existing = db.get(UserAbility, {"user_id": user_id, "ability_key": ability_key})
+    if not existing:
+        db.add(UserAbility(user_id=user_id, ability_key=ability_key))
+        db.commit()
+
+
+@router.delete(
+    "/users/{user_id}/abilities/{ability_key}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def revoke_ability(
+    user_id: uuid.UUID,
+    ability_key: str,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> None:
+    row = db.get(UserAbility, {"user_id": user_id, "ability_key": ability_key})
+    if row:
+        db.delete(row)
+        db.commit()

--- a/backend/src/formulation_ai/schemas/auth.py
+++ b/backend/src/formulation_ai/schemas/auth.py
@@ -18,6 +18,8 @@ class UserRead(BaseModel):
     email: str
     full_name: str | None
     is_active: bool
+    is_admin: bool
+    abilities: list[str] = []
 
 
 class Token(BaseModel):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { PortfolioPage } from '@/pages/PortfolioPage'
 import { ProjectDetailPage } from '@/pages/ProjectDetailPage'
 import { UploadPage } from '@/pages/UploadPage'
 import { IngredientsPage } from '@/pages/IngredientsPage'
+import { SettingsPage } from '@/pages/SettingsPage'
 
 export default function App() {
   return (
@@ -25,6 +26,7 @@ export default function App() {
             <Route path="/projects/:id" element={<ProjectDetailPage />} />
             <Route path="/upload" element={<UploadPage />} />
             <Route path="/ingredients" element={<IngredientsPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
           </Route>
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -28,7 +28,6 @@ const nav = [
 ]
 
 const secondaryNav = [
-  { to: '/settings', label: 'Settings', icon: Settings, disabled: true },
   { to: '/help', label: 'Help', icon: HelpCircle, disabled: true },
 ]
 
@@ -61,6 +60,9 @@ export function AppShell() {
             <p className="mt-6 px-3 pb-1.5 pt-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
               System
             </p>
+            {user?.is_admin && (
+              <NavItem to="/settings" label="Settings" icon={Settings} />
+            )}
             {secondaryNav.map((item) => (
               <NavItem key={item.to} {...item} />
             ))}
@@ -130,6 +132,7 @@ function Breadcrumb() {
   const { pathname } = useLocation()
   if (pathname === '/') return <span className="hidden md:inline text-muted-foreground/60">Portfolio overview</span>
   if (pathname === '/ingredients') return <span className="hidden md:inline text-foreground font-medium">Ingredients</span>
+  if (pathname === '/settings') return <span className="hidden md:inline text-foreground font-medium">Settings</span>
   if (pathname === '/upload') return (
     <span className="hidden md:inline">
       <span className="text-muted-foreground/60">Portfolio</span>

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -8,6 +8,8 @@ export interface CurrentUser {
   email: string
   full_name: string | null
   is_active: boolean
+  is_admin: boolean
+  abilities: string[]
 }
 
 interface AuthContextValue {
@@ -16,6 +18,8 @@ interface AuthContextValue {
   login: (email: string, password: string) => Promise<void>
   logout: () => void
   refresh: () => Promise<void>
+  /** Returns true if the user is an admin or has the named ability explicitly granted. */
+  hasAbility: (key: string) => boolean
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined)
@@ -63,9 +67,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null)
   }, [])
 
+  const hasAbility = useCallback(
+    (key: string) => {
+      if (!user) return false
+      if (user.is_admin) return true
+      return user.abilities.includes(key)
+    },
+    [user],
+  )
+
   const value = useMemo(
-    () => ({ user, loading, login, logout, refresh }),
-    [user, loading, login, logout, refresh],
+    () => ({ user, loading, login, logout, refresh, hasAbility }),
+    [user, loading, login, logout, refresh, hasAbility],
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,269 @@
+import { useEffect, useState } from 'react'
+import { Navigate } from 'react-router-dom'
+import { Loader2, Plus, ShieldCheck } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { apiFetch } from '@/lib/api'
+import { useAuth } from '@/lib/auth'
+
+// ---------------------------------------------------------------------------
+// API types
+// ---------------------------------------------------------------------------
+interface AbilityOut {
+  key: string
+  description: string | null
+}
+
+interface UserWithAbilities {
+  id: string
+  email: string
+  full_name: string | null
+  is_active: boolean
+  is_admin: boolean
+  abilities: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Settings page (admin only)
+// ---------------------------------------------------------------------------
+export function SettingsPage() {
+  const { user } = useAuth()
+
+  if (!user?.is_admin) return <Navigate to="/" replace />
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-8 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+        <p className="mt-1 text-sm text-muted-foreground">Admin configuration for this workspace.</p>
+      </div>
+      <UserAbilitiesMatrix />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// User × Ability matrix
+// ---------------------------------------------------------------------------
+function UserAbilitiesMatrix() {
+  const [users, setUsers] = useState<UserWithAbilities[]>([])
+  const [abilities, setAbilities] = useState<AbilityOut[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [toggling, setToggling] = useState<string | null>(null) // "userId:key"
+  const [addingAbility, setAddingAbility] = useState(false)
+  const [newKey, setNewKey] = useState('')
+  const [newDesc, setNewDesc] = useState('')
+  const [addError, setAddError] = useState<string | null>(null)
+
+  const load = async () => {
+    try {
+      const [u, a] = await Promise.all([
+        apiFetch<UserWithAbilities[]>('/admin/users'),
+        apiFetch<AbilityOut[]>('/admin/abilities'),
+      ])
+      setUsers(u)
+      setAbilities(a)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        await load()
+      } catch {
+        // load() sets its own error state
+      }
+    }
+    void init()
+  }, [])
+
+  const toggle = async (userId: string, abilityKey: string, currentlyGranted: boolean) => {
+    const id = `${userId}:${abilityKey}`
+    setToggling(id)
+    try {
+      if (currentlyGranted) {
+        await apiFetch(`/admin/users/${userId}/abilities/${abilityKey}`, { method: 'DELETE' })
+      } else {
+        await apiFetch(`/admin/users/${userId}/abilities/${abilityKey}`, { method: 'POST' })
+      }
+      setUsers((prev) =>
+        prev.map((u) => {
+          if (u.id !== userId) return u
+          return {
+            ...u,
+            abilities: currentlyGranted
+              ? u.abilities.filter((k) => k !== abilityKey)
+              : [...u.abilities, abilityKey],
+          }
+        }),
+      )
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Toggle failed')
+    } finally {
+      setToggling(null)
+    }
+  }
+
+  const handleAddAbility = async () => {
+    const key = newKey.trim().toLowerCase().replace(/\s+/g, '_')
+    if (!key) return
+    setAddError(null)
+    try {
+      const created = await apiFetch<AbilityOut>('/admin/abilities', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key, description: newDesc.trim() || null }),
+      })
+      setAbilities((prev) => [...prev, created])
+      setNewKey('')
+      setNewDesc('')
+      setAddingAbility(false)
+    } catch (e) {
+      setAddError(e instanceof Error ? e.message : 'Failed to add ability')
+    }
+  }
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-16">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-sm text-destructive">{error}</CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-4">
+        <div>
+          <CardTitle className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-brand" />
+            User Abilities
+          </CardTitle>
+          <CardDescription className="mt-1">
+            Check a cell to grant an ability to a user. Admins have all abilities implicitly.
+          </CardDescription>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setAddingAbility((v) => !v)}
+        >
+          <Plus className="h-4 w-4" />
+          Add ability
+        </Button>
+      </CardHeader>
+
+      {addingAbility && (
+        <div className="mx-6 mb-4 rounded-lg border bg-muted/40 p-4">
+          <p className="mb-3 text-sm font-medium">New ability</p>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <input
+              className="flex-1 rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+              placeholder="ability_key (e.g. run_iterations)"
+              value={newKey}
+              onChange={(e) => setNewKey(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && void handleAddAbility()}
+            />
+            <input
+              className="flex-1 rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+              placeholder="Description (optional)"
+              value={newDesc}
+              onChange={(e) => setNewDesc(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && void handleAddAbility()}
+            />
+            <Button size="sm" onClick={() => void handleAddAbility()} disabled={!newKey.trim()}>
+              Save
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => { setAddingAbility(false); setAddError(null) }}>
+              Cancel
+            </Button>
+          </div>
+          {addError && <p className="mt-2 text-xs text-destructive">{addError}</p>}
+        </div>
+      )}
+
+      <CardContent className="overflow-x-auto">
+        {abilities.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No abilities defined yet. Click "Add ability" to create one.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b">
+                <th className="pb-3 pr-6 text-left font-medium text-muted-foreground">User</th>
+                {abilities.map((a) => (
+                  <th key={a.key} className="pb-3 px-4 text-center font-medium text-muted-foreground" title={a.description ?? ''}>
+                    <span className="block max-w-[120px] truncate">{a.key}</span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((u) => (
+                <tr key={u.id} className="border-b last:border-0 hover:bg-muted/30 transition-colors">
+                  <td className="py-3 pr-6">
+                    <div className="font-medium">{u.full_name || u.email}</div>
+                    {u.full_name && (
+                      <div className="text-xs text-muted-foreground">{u.email}</div>
+                    )}
+                    {u.is_admin && (
+                      <Badge variant="secondary" className="mt-0.5 text-[10px]">admin</Badge>
+                    )}
+                  </td>
+                  {abilities.map((a) => {
+                    const granted = u.abilities.includes(a.key)
+                    const cellId = `${u.id}:${a.key}`
+                    const busy = toggling === cellId
+                    return (
+                      <td key={a.key} className="px-4 py-3 text-center">
+                        {u.is_admin ? (
+                          <span className="text-muted-foreground/40" title="Admins have all abilities">—</span>
+                        ) : (
+                          <button
+                            onClick={() => void toggle(u.id, a.key, granted)}
+                            disabled={busy}
+                            className="inline-flex h-5 w-5 items-center justify-center rounded"
+                            aria-label={`${granted ? 'Revoke' : 'Grant'} ${a.key} for ${u.email}`}
+                          >
+                            {busy ? (
+                              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                            ) : (
+                              <span
+                                className={`h-4 w-4 rounded border-2 transition-colors ${
+                                  granted
+                                    ? 'border-brand bg-brand'
+                                    : 'border-muted-foreground/40 bg-transparent hover:border-brand'
+                                }`}
+                              />
+                            )}
+                          </button>
+                        )}
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
Closes #3.

## What's in this PR

### Data model
- `is_admin BOOLEAN` on `users` (demo users david/nate/jun seeded as admin)
- `abilities` table: `{key, description}` — defines what abilities exist
- `user_abilities` join table: `{user_id, ability_key}` — which users have which abilities
- Seeds `manage_ingredients` as the first example ability definition

### Backend
- `Ability` + `UserAbility` ORM models with CASCADE deletes
- `User.abilities` property returns granted ability keys (lazy-loaded)
- `UserRead` schema now includes `is_admin: bool` and `abilities: list[str]`
- `get_current_admin` dependency — 403 if not admin
- `/admin` router (all require admin):
  - `GET /admin/abilities` — list defined abilities
  - `POST /admin/abilities` — add a new ability definition
  - `GET /admin/users` — list all users with their granted abilities
  - `POST /admin/users/{id}/abilities/{key}` — grant
  - `DELETE /admin/users/{id}/abilities/{key}` — revoke
- `GET /auth/me` now returns `is_admin` and `abilities`

### Frontend
- `CurrentUser` type: + `is_admin`, + `abilities`
- `hasAbility(key)` in auth context — admins always return `true`
- Settings nav entry visible only to admins
- `/settings` route → `SettingsPage` — redirects non-admins to `/`
- User × ability matrix with instant checkbox toggles
- Inline "Add ability" form (key + optional description)

## What's NOT in this PR (per plan)
- No feature gates wired yet — the framework is in place, future tickets add checks
- No ability auto-discovery from code — abilities are defined/managed in the UI

## Test plan
- [ ] `uv run alembic upgrade head` — runs cleanly
- [ ] `uv run pytest -q` — 28 passing
- [ ] Log in as `david` → Settings appears in nav
- [ ] Settings matrix shows 3 users × 1 ability (`manage_ingredients`)
- [ ] Check checkbox → ability granted; uncheck → revoked; reload confirms
- [ ] "Add ability" form → new column appears in matrix
- [ ] Log in as a newly registered user → no Settings link; `/settings` redirects to `/`