### PR TITLE
Fix ability form 422 and prune EC2 disk before deploys

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -58,6 +58,7 @@ jobs:
             --timeout-seconds 600 \
             --parameters commands='[
               "set -e",
+              "docker image prune -af",
               "aws ecr get-login-password --region '"$AWS_REGION"' | docker login --username AWS --password-stdin '"$ECR_REGISTRY"'",
               "docker pull '"$IMAGE"'",
               "docker run --rm --network host --env-file '"$ENV_FILE"' '"$IMAGE"' alembic upgrade head",

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -57,6 +57,7 @@ jobs:
             --timeout-seconds 300 \
             --parameters commands='[
               "set -e",
+              "docker image prune -af",
               "aws ecr get-login-password --region '"$AWS_REGION"' | docker login --username AWS --password-stdin '"$ECR_REGISTRY"'",
               "docker pull '"$IMAGE"'",
               "docker stop '"$CONTAINER_NGINX"' || true && docker rm '"$CONTAINER_NGINX"' || true",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -117,8 +117,7 @@ function UserAbilitiesMatrix() {
     try {
       const created = await apiFetch<AbilityOut>('/admin/abilities', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ key, description: newDesc.trim() || null }),
+        body: { key, description: newDesc.trim() || null },
       })
       setAbilities((prev) => [...prev, created])
       setNewKey('')


### PR DESCRIPTION
## Summary
- **Settings page**: `handleAddAbility` was double-serializing the JSON body (`JSON.stringify` in the call site + `apiFetch` serializes again) → FastAPI returned 422 Unprocessable Content. Fixed by passing the raw object to `apiFetch`.
- **Deploy workflows**: Add `docker image prune -af` as first SSM command in both `deploy-backend.yml` and `deploy-frontend.yml`, so stale images are removed before pulling the new one. Prevents "no space left on device" failures on EC2.

## Test plan
- [ ] Add a new ability in Settings → should succeed (no 422)
- [ ] Push to main → backend/frontend deploys complete without disk-full error