### PR TITLE
Add non-admin demo researcher for ability matrix

### DIFF
--- a/backend/alembic/versions/0008_seed_demo_researcher.py
+++ b/backend/alembic/versions/0008_seed_demo_researcher.py
@@ -1,0 +1,64 @@
+"""Seed non-admin demo researcher account
+
+Revision ID: 0008_seed_demo_researcher
+Revises: 0007_user_abilities
+Create Date: 2026-04-27
+
+Adds a non-admin demo account so the User Abilities matrix has at least one
+row with clickable checkboxes (admin rows always show '—').
+"""
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from passlib.context import CryptContext
+
+from alembic import op
+
+revision: str = "0008_seed_demo_researcher"
+down_revision: str | Sequence[str] | None = "0007_user_abilities"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+DEMO_PASSWORD = "demo123"
+RESEARCHER_EMAIL = "researcher"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = bind.execute(
+        sa.text("SELECT 1 FROM users WHERE email = :email"),
+        {"email": RESEARCHER_EMAIL},
+    ).first()
+    if existing:
+        return
+    pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    users = sa.table(
+        "users",
+        sa.column("id", sa.dialects.postgresql.UUID(as_uuid=True)),
+        sa.column("email", sa.String),
+        sa.column("password_hash", sa.String),
+        sa.column("full_name", sa.String),
+        sa.column("is_active", sa.Boolean),
+        sa.column("is_admin", sa.Boolean),
+    )
+    bind.execute(
+        users.insert().values(
+            id=uuid.uuid4(),
+            email=RESEARCHER_EMAIL,
+            password_hash=pwd.hash(DEMO_PASSWORD),
+            full_name="Sam Researcher",
+            is_active=True,
+            is_admin=False,
+        )
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("DELETE FROM users WHERE email = :email"),
+        {"email": RESEARCHER_EMAIL},
+    )

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Navigate } from 'react-router-dom'
-import { Loader2, Plus, ShieldCheck } from 'lucide-react'
+import { Check, Loader2, Plus, ShieldCheck } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -237,7 +237,9 @@ function UserAbilitiesMatrix() {
                             className="inline-flex h-5 w-5 cursor-default items-center justify-center rounded"
                             title="Admin — all abilities granted implicitly"
                           >
-                            <span className="h-4 w-4 rounded border-2 border-muted-foreground/30 bg-muted-foreground/20" />
+                            <span className="inline-flex h-4 w-4 items-center justify-center rounded border-2 border-muted-foreground/40 bg-muted-foreground/20">
+                              <Check className="h-2.5 w-2.5 text-muted-foreground/60" strokeWidth={3} />
+                            </span>
                           </span>
                         ) : (
                           <button

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -233,7 +233,12 @@ function UserAbilitiesMatrix() {
                     return (
                       <td key={a.key} className="px-4 py-3 text-center">
                         {u.is_admin ? (
-                          <span className="text-muted-foreground/40" title="Admins have all abilities">—</span>
+                          <span
+                            className="inline-flex h-5 w-5 cursor-default items-center justify-center rounded"
+                            title="Admin — all abilities granted implicitly"
+                          >
+                            <span className="h-4 w-4 rounded border-2 border-muted-foreground/30 bg-muted-foreground/20" />
+                          </span>
                         ) : (
                           <button
                             onClick={() => void toggle(u.id, a.key, granted)}


### PR DESCRIPTION
## Summary
All three demo accounts (david, nate, jun) are admins. Admin rows show `—` in the ability matrix — no checkboxes to click. Migration `0008` seeds a fourth account **researcher / demo123** (`is_admin=false`) so the matrix has at least one row with functional grant/revoke checkboxes.

## Test plan
- [ ] Run `alembic upgrade head` on local and EC2
- [ ] Load Settings → matrix now shows a "Sam Researcher" row with empty checkboxes
- [ ] Click a checkbox → ability granted; click again → revoked