### PR TITLE
feat(#6): Add logo to login page

### DIFF
--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -3,12 +3,13 @@ import { cn } from '@/lib/utils'
 interface LogoProps {
   className?: string
   variant?: 'mark' | 'wordmark'
+  size?: 'sm' | 'lg'
 }
 
-export function Logo({ className, variant = 'wordmark' }: LogoProps) {
+export function Logo({ className, variant = 'wordmark', size = 'sm' }: LogoProps) {
   return (
     <div className={cn('flex items-center gap-2', className)}>
-      <svg viewBox="0 0 32 32" className="h-7 w-7" aria-hidden="true">
+      <svg viewBox="0 0 32 32" className={size === 'lg' ? 'h-12 w-12' : 'h-7 w-7'} aria-hidden="true">
         <defs>
           <linearGradient id="fa-grad" x1="0" x2="1" y1="0" y2="1">
             <stop offset="0%" stopColor="hsl(221 83% 48%)" />
@@ -31,10 +32,10 @@ export function Logo({ className, variant = 'wordmark' }: LogoProps) {
       </svg>
       {variant === 'wordmark' && (
         <div className="flex flex-col leading-none">
-          <span className="text-sm font-semibold tracking-tight text-foreground">
+          <span className={cn('font-semibold tracking-tight text-foreground', size === 'lg' ? 'text-xl' : 'text-sm')}>
             Formulation<span className="text-brand">·AI</span>
           </span>
-          <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          <span className={cn('font-medium uppercase tracking-wider text-muted-foreground', size === 'lg' ? 'text-xs mt-0.5' : 'text-[10px]')}>
             Closed-loop optimization
           </span>
         </div>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from 'react'
 import { Navigate, useLocation, useNavigate } from 'react-router-dom'
+import { Logo } from '@/components/Logo'
 import { useAuth } from '@/lib/auth'
 import { ApiError } from '@/lib/api'
 
@@ -34,53 +35,56 @@ export function LoginPage() {
 
   return (
     <div className="flex h-full items-center justify-center bg-background px-4">
-      <form
-        onSubmit={handleSubmit}
-        className="w-full max-w-sm rounded-lg border bg-card p-6 shadow-sm"
-      >
-        <h1 className="text-xl font-semibold text-foreground">Sign in</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Formulation-AI</p>
-
-        <label className="mt-6 block text-sm font-medium text-foreground">
-          Username
-          <input
-            type="text"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            autoFocus
-            autoComplete="username"
-            spellCheck={false}
-            autoCapitalize="off"
-            className="mt-1 block w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
-          />
-        </label>
-
-        <label className="mt-4 block text-sm font-medium text-foreground">
-          Password
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            className="mt-1 block w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
-          />
-        </label>
-
-        {error && (
-          <p className="mt-4 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            {error}
-          </p>
-        )}
-
-        <button
-          type="submit"
-          disabled={submitting}
-          className="mt-6 w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-60"
+      <div className="w-full max-w-sm space-y-6">
+        <Logo size="lg" className="justify-center" />
+        <form
+          onSubmit={handleSubmit}
+          className="rounded-lg border bg-card p-6 shadow-sm"
         >
-          {submitting ? 'Signing in…' : 'Sign in'}
-        </button>
-      </form>
+          <h1 className="text-xl font-semibold text-foreground">Sign in</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Enter your credentials to continue.</p>
+
+          <label className="mt-6 block text-sm font-medium text-foreground">
+            Username
+            <input
+              type="text"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoFocus
+              autoComplete="username"
+              spellCheck={false}
+              autoCapitalize="off"
+              className="mt-1 block w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+            />
+          </label>
+
+          <label className="mt-4 block text-sm font-medium text-foreground">
+            Password
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="mt-1 block w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+            />
+          </label>
+
+          {error && (
+            <p className="mt-4 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="mt-6 w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-60"
+          >
+            {submitting ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Logo component now accepts `size='sm' | 'lg'` (sidebar stays `sm`)
- Login page renders the wordmark centered above the card at `lg` size (h-12 icon, xl text)
- Replaced "Formulation-AI" subtitle with "Enter your credentials to continue."

Closes #6