### PR TITLE
feat: add user management to settings with manage_users ability

### DIFF
--- a/backend/alembic/versions/0009_add_user_name_fields_and_manage_users.py
+++ b/backend/alembic/versions/0009_add_user_name_fields_and_manage_users.py
@@ -1,0 +1,48 @@
+"""Add first_name/last_name to users; seed manage_users ability; grant to admins
+
+Revision ID: 0009
+Revises: 0008_seed_demo_researcher
+Create Date: 2026-05-02
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0009"
+down_revision = "0008_seed_demo_researcher"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- Add first_name & last_name to users ---
+    op.add_column("users", sa.Column("first_name", sa.String(128), nullable=True))
+    op.add_column("users", sa.Column("last_name", sa.String(128), nullable=True))
+
+    # --- Seed manage_users ability ---
+    op.execute(
+        sa.text(
+            "INSERT INTO abilities (key, description) VALUES "
+            "('manage_users', 'Create and delete user accounts')"
+        )
+    )
+
+    # --- Grant manage_users to existing admins ---
+    op.execute(
+        sa.text(
+            "INSERT INTO user_abilities (user_id, ability_key) "
+            "SELECT id, 'manage_users' FROM users WHERE is_admin = TRUE"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("DELETE FROM user_abilities WHERE ability_key = 'manage_users'")
+    )
+    op.execute(sa.text("DELETE FROM abilities WHERE key = 'manage_users'"))
+    op.drop_column("users", "last_name")
+    op.drop_column("users", "first_name")

--- a/backend/src/formulation_ai/auth.py
+++ b/backend/src/formulation_ai/auth.py
@@ -67,6 +67,22 @@ def get_current_admin(current_user: User = Depends(get_current_user)) -> User:
     return current_user
 
 
+def require_ability(ability_key: str):
+    """Dependency factory — checks that the current user is admin or has the named ability."""
+
+    def check(current_user: User = Depends(get_current_user)) -> User:
+        if current_user.is_admin:
+            return current_user
+        if ability_key not in (current_user.abilities or []):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Ability '{ability_key}' required",
+            )
+        return current_user
+
+    return check
+
+
 def authenticate(db: Session, email: str, password: str) -> User | None:
     user = db.query(User).filter(User.email == email).first()
     if not user or not user.password_hash:

--- a/backend/src/formulation_ai/models/user.py
+++ b/backend/src/formulation_ai/models/user.py
@@ -16,6 +16,8 @@ class User(Base, TimestampMixin):
     email: Mapped[str] = mapped_column(String(320), unique=True, index=True, nullable=False)
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     full_name: Mapped[str | None] = mapped_column(String(256))
+    first_name: Mapped[str | None] = mapped_column(String(128))
+    last_name: Mapped[str | None] = mapped_column(String(128))
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     is_admin: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="false", nullable=False

--- a/backend/src/formulation_ai/routers/admin.py
+++ b/backend/src/formulation_ai/routers/admin.py
@@ -10,6 +10,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import exc as sa_exc
 from sqlalchemy.orm import Session
 
 from formulation_ai.auth import get_current_admin, hash_password, require_ability
@@ -141,10 +142,14 @@ def revoke_ability(
 def create_user(
     payload: AdminUserCreate,
     db: Session = Depends(get_db),
-    _: User = Depends(require_ability("manage_users")),
+    current_user: User = Depends(require_ability("manage_users")),
 ) -> User:
-    if db.query(User).filter(User.email == payload.email).first():
-        raise HTTPException(status_code=400, detail="email already registered")
+    # Only admins may create admin accounts
+    if payload.is_admin and not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only admins can create admin accounts",
+        )
     user = User(
         email=payload.email,
         password_hash=hash_password(payload.password),
@@ -154,7 +159,11 @@ def create_user(
         is_admin=payload.is_admin,
     )
     db.add(user)
-    db.commit()
+    try:
+        db.commit()
+    except sa_exc.IntegrityError as err:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="email already registered") from err
     db.refresh(user)
     return user
 

--- a/backend/src/formulation_ai/routers/admin.py
+++ b/backend/src/formulation_ai/routers/admin.py
@@ -1,14 +1,18 @@
-"""Admin router — user/ability management. All routes require is_admin."""
+"""Admin router — user/ability management.
+
+Ability management routes require is_admin.
+User management routes require manage_users ability (or is_admin).
+"""
 
 from __future__ import annotations
 
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
-from formulation_ai.auth import get_current_admin
+from formulation_ai.auth import get_current_admin, hash_password, require_ability
 from formulation_ai.db import get_db
 from formulation_ai.models import Ability, User, UserAbility
 
@@ -35,9 +39,19 @@ class UserWithAbilities(BaseModel):
     id: uuid.UUID
     email: str
     full_name: str | None
+    first_name: str | None = None
+    last_name: str | None = None
     is_active: bool
     is_admin: bool
     abilities: list[str] = []
+
+
+class AdminUserCreate(BaseModel):
+    email: str = Field(min_length=1, max_length=320)
+    password: str = Field(min_length=6, max_length=128)
+    first_name: str | None = None
+    last_name: str | None = None
+    is_admin: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -113,3 +127,56 @@ def revoke_ability(
     if row:
         db.delete(row)
         db.commit()
+
+
+# ---------------------------------------------------------------------------
+# User management (requires manage_users ability)
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/users",
+    response_model=UserWithAbilities,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_user(
+    payload: AdminUserCreate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_ability("manage_users")),
+) -> User:
+    if db.query(User).filter(User.email == payload.email).first():
+        raise HTTPException(status_code=400, detail="email already registered")
+    user = User(
+        email=payload.email,
+        password_hash=hash_password(payload.password),
+        first_name=payload.first_name,
+        last_name=payload.last_name,
+        full_name=_build_full_name(payload.first_name, payload.last_name),
+        is_admin=payload.is_admin,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.delete(
+    "/users/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_user(
+    user_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_ability("manage_users")),
+) -> None:
+    if user_id == current_user.id:
+        raise HTTPException(status_code=400, detail="cannot delete yourself")
+    user = db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    db.delete(user)
+    db.commit()
+
+
+def _build_full_name(first_name: str | None, last_name: str | None) -> str | None:
+    parts = [p for p in (first_name, last_name) if p]
+    return " ".join(parts) if parts else None

--- a/backend/src/formulation_ai/routers/auth.py
+++ b/backend/src/formulation_ai/routers/auth.py
@@ -24,6 +24,8 @@ def register(payload: UserCreate, db: Session = Depends(get_db)) -> User:
         email=payload.email,
         password_hash=hash_password(payload.password),
         full_name=payload.full_name,
+        first_name=payload.first_name,
+        last_name=payload.last_name,
     )
     db.add(user)
     db.commit()

--- a/backend/src/formulation_ai/schemas/auth.py
+++ b/backend/src/formulation_ai/schemas/auth.py
@@ -9,6 +9,9 @@ class UserCreate(BaseModel):
     email: str = Field(min_length=1, max_length=320)
     password: str = Field(min_length=6, max_length=128)
     full_name: str | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+    is_admin: bool = False
 
 
 class UserRead(BaseModel):
@@ -17,6 +20,8 @@ class UserRead(BaseModel):
     id: uuid.UUID
     email: str
     full_name: str | None
+    first_name: str | None = None
+    last_name: str | None = None
     is_active: bool
     is_admin: bool
     abilities: list[str] = []

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -33,7 +33,7 @@ const secondaryNav = [
 
 export function AppShell() {
   const navigate = useNavigate()
-  const { user, logout } = useAuth()
+  const { user, logout, hasAbility } = useAuth()
   const displayName = user?.full_name || user?.email?.split('@')[0] || 'Researcher'
   const initials = displayName
     .split(/[\s.]+/)
@@ -60,7 +60,7 @@ export function AppShell() {
             <p className="mt-6 px-3 pb-1.5 pt-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
               System
             </p>
-            {user?.is_admin && (
+            {(user?.is_admin || hasAbility('manage_users')) && (
               <NavItem to="/settings" label="Settings" icon={Settings} />
             )}
             {secondaryNav.map((item) => (

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export const Dialog = DialogPrimitive.Root
+export const DialogTrigger = DialogPrimitive.Trigger
+export const DialogClose = DialogPrimitive.Close
+
+export const DialogPortal = DialogPrimitive.Portal
+
+export const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = 'DialogOverlay'
+
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 w-full max-w-lg translate-x-[-50%] translate-y-[-50%] rounded-lg border bg-card p-6 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = 'DialogContent'
+
+export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+)
+
+export const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    {...props}
+  />
+)
+
+export const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = 'DialogTitle'
+
+export const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = 'DialogDescription'

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -7,6 +7,8 @@ export interface CurrentUser {
   id: string
   email: string
   full_name: string | null
+  first_name: string | null
+  last_name: string | null
   is_active: boolean
   is_admin: boolean
   abilities: string[]

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,9 +1,18 @@
 import { useEffect, useState } from 'react'
 import { Navigate } from 'react-router-dom'
-import { Check, Loader2, Plus, ShieldCheck } from 'lucide-react'
+import { Check, Loader2, Plus, ShieldCheck, Trash2, UserPlus, Users } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 import { apiFetch } from '@/lib/api'
 import { useAuth } from '@/lib/auth'
 
@@ -19,32 +28,353 @@ interface UserWithAbilities {
   id: string
   email: string
   full_name: string | null
+  first_name: string | null
+  last_name: string | null
   is_active: boolean
   is_admin: boolean
   abilities: string[]
 }
 
 // ---------------------------------------------------------------------------
-// Settings page (admin only)
+// Settings page (admin or manage_users ability required)
 // ---------------------------------------------------------------------------
 export function SettingsPage() {
-  const { user } = useAuth()
+  const { user, hasAbility } = useAuth()
 
-  if (!user?.is_admin) return <Navigate to="/" replace />
+  const canAccess = user?.is_admin || hasAbility('manage_users')
+  if (!canAccess) return <Navigate to="/" replace />
 
   return (
     <div className="mx-auto max-w-5xl space-y-8 p-6">
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Admin configuration for this workspace.</p>
+        <p className="mt-1 text-sm text-muted-foreground">Workspace configuration and user management.</p>
       </div>
-      <UserAbilitiesMatrix />
+
+      <UserManagement />
+      {user?.is_admin && <UserAbilitiesMatrix />}
     </div>
   )
 }
 
 // ---------------------------------------------------------------------------
-// User × Ability matrix
+// User management section
+// ---------------------------------------------------------------------------
+function UserManagement() {
+  const { user: currentUser } = useAuth()
+  const [users, setUsers] = useState<UserWithAbilities[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showCreateDialog, setShowCreateDialog] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<UserWithAbilities | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  const loadUsers = async () => {
+    try {
+      const data = await apiFetch<UserWithAbilities[]>('/admin/users')
+      setUsers(data)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load users')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        await loadUsers()
+      } catch {
+        // loadUsers() sets its own error state
+      }
+    }
+    void init()
+  }, [])
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return
+    setDeleting(true)
+    try {
+      await apiFetch(`/admin/users/${deleteTarget.id}`, { method: 'DELETE' })
+      setUsers((prev) => prev.filter((u) => u.id !== deleteTarget.id))
+      setDeleteTarget(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Delete failed')
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  const displayName = (u: UserWithAbilities) => {
+    if (u.first_name || u.last_name) return [u.first_name, u.last_name].filter(Boolean).join(' ') || u.email
+    return u.full_name || u.email
+  }
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-16">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between gap-4">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Users className="h-5 w-5 text-brand" />
+              Users
+            </CardTitle>
+            <CardDescription className="mt-1">
+              Create and manage user accounts for this workspace.
+            </CardDescription>
+          </div>
+          <Button size="sm" variant="outline" onClick={() => setShowCreateDialog(true)}>
+            <UserPlus className="h-4 w-4" />
+            Add user
+          </Button>
+        </CardHeader>
+
+        {error && (
+          <div className="mx-6 mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        <CardContent className="overflow-x-auto">
+          {users.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              No users found. Click "Add user" to create one.
+            </p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="pb-3 pr-6 text-left font-medium text-muted-foreground">Name</th>
+                  <th className="pb-3 pr-6 text-left font-medium text-muted-foreground">Email</th>
+                  <th className="pb-3 pr-6 text-center font-medium text-muted-foreground">Role</th>
+                  <th className="pb-3 pr-6 text-center font-medium text-muted-foreground">Abilities</th>
+                  <th className="pb-3 w-16 text-right font-medium text-muted-foreground" />
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u) => {
+                  const isSelf = u.id === currentUser?.id
+                  return (
+                    <tr key={u.id} className="border-b last:border-0 hover:bg-muted/30 transition-colors">
+                      <td className="py-3 pr-6 font-medium">
+                        {displayName(u)}
+                        {isSelf && (
+                          <Badge variant="secondary" className="ml-2 text-[10px]">you</Badge>
+                        )}
+                      </td>
+                      <td className="py-3 pr-6 text-muted-foreground">{u.email}</td>
+                      <td className="py-3 pr-6 text-center">
+                        {u.is_admin ? (
+                          <Badge variant="default" className="text-[10px]">Admin</Badge>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">User</span>
+                        )}
+                      </td>
+                      <td className="py-3 pr-6 text-center">
+                        <span className="text-xs text-muted-foreground">
+                          {u.abilities.length > 0 ? u.abilities.join(', ') : '—'}
+                        </span>
+                      </td>
+                      <td className="py-3 text-right">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                          disabled={isSelf}
+                          onClick={() => setDeleteTarget(u)}
+                          title={isSelf ? 'Cannot delete yourself' : 'Delete user'}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Create user dialog */}
+      {showCreateDialog && (
+        <CreateUserDialog
+          open={showCreateDialog}
+          onOpenChange={setShowCreateDialog}
+          onCreated={(newUser) => {
+            setUsers((prev) => [...prev, newUser])
+            setShowCreateDialog(false)
+          }}
+        />
+      )}
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={!!deleteTarget} onOpenChange={(v) => { if (!v) setDeleteTarget(null) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete user</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete{' '}
+              <span className="font-medium text-foreground">
+                {deleteTarget ? displayName(deleteTarget) : ''}
+              </span>
+              ? This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDeleteTarget(null)} disabled={deleting}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={() => void handleDelete()} disabled={deleting}>
+              {deleting && <Loader2 className="h-4 w-4 animate-spin" />}
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Create user dialog
+// ---------------------------------------------------------------------------
+function CreateUserDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onCreated: (user: UserWithAbilities) => void
+}) {
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [isAdmin, setIsAdmin] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async () => {
+    if (!email.trim() || !password.trim()) return
+    setError(null)
+    setSubmitting(true)
+    try {
+      const created = await apiFetch<UserWithAbilities>('/admin/users', {
+        method: 'POST',
+        body: {
+          email: email.trim(),
+          password: password,
+          first_name: firstName.trim() || null,
+          last_name: lastName.trim() || null,
+          is_admin: isAdmin,
+        },
+      })
+      onCreated(created)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create user')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add user</DialogTitle>
+          <DialogDescription>
+            Create a new user account for this workspace.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-muted-foreground">First name</label>
+              <Input
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                placeholder="Jane"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-muted-foreground">Last name</label>
+              <Input
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                placeholder="Smith"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">Email / Username</label>
+            <Input
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="jane.smith@example.com"
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">Password</label>
+            <Input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Min. 6 characters"
+              autoComplete="new-password"
+              onKeyDown={(e) => e.key === 'Enter' && void handleSubmit()}
+            />
+          </div>
+
+          <label className="flex items-center gap-2.5 pt-1">
+            <input
+              type="checkbox"
+              checked={isAdmin}
+              onChange={(e) => setIsAdmin(e.target.checked)}
+              className="h-4 w-4 rounded border-input text-brand focus:ring-brand"
+            />
+            <span className="text-sm">Admin user</span>
+            <span className="text-xs text-muted-foreground">
+              (grants all abilities implicitly)
+            </span>
+          </label>
+        </div>
+
+        {error && (
+          <p className="text-sm text-destructive">{error}</p>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSubmit()} disabled={!email.trim() || !password.trim() || submitting}>
+            {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+            Create user
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// User × Ability matrix (admin only)
 // ---------------------------------------------------------------------------
 function UserAbilitiesMatrix() {
   const [users, setUsers] = useState<UserWithAbilities[]>([])


### PR DESCRIPTION
## Summary

Adds user management capabilities to the Settings page, controlled by a new `manage_users` ability.

### Backend
- **Migration 0009**: Adds `first_name`/`last_name` columns to users, seeds `manage_users` ability, grants to existing admins
- **`require_ability()`** dependency factory in `auth.py` — checks `is_admin` OR explicit ability grant
- **`POST /admin/users`** — create user (requires `manage_users`)
- **`DELETE /admin/users/{user_id}`** — delete user (requires `manage_users`, can't delete yourself)
- User create accepts: first name, last name, email, password, is_admin flag

### Frontend
- **User Management section** in Settings — table of all users with add/delete
- **Add User dialog** with fields for first name, last name, email, password, admin checkbox
- **Delete confirmation dialog** — disabled for the currently logged-in user
- Settings page access: `is_admin` OR `manage_users` ability (was admin-only)
- New **Dialog** component (shadcn-style on `@radix-ui/react-dialog`)
- AppShell nav shows Settings for `manage_users` holders too