### PR TITLE
chore: add CODEOWNERS requiring David's approval on all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# David must approve all PRs before merging
+* @DavidJBarnes


### PR DESCRIPTION
Adds a CODEOWNERS file designating @DavidJBarnes as the required reviewer for all code.

Combined with branch protection (already configured):
- **Require a PR before merging** ✅
- **Require code owner review** ✅  
- **Dismiss stale reviews on new commits** ✅
- **Enforce for admins too** ✅

Result: every PR to `main` must be approved by David before it can be merged.