### PR TITLE
fix: allow manage_users holders to list users

### DIFF
--- a/backend/src/formulation_ai/routers/admin.py
+++ b/backend/src/formulation_ai/routers/admin.py
@@ -89,7 +89,7 @@ def create_ability(
 @router.get("/users", response_model=list[UserWithAbilities])
 def list_users(
     db: Session = Depends(get_db),
-    _: User = Depends(get_current_admin),
+    _: User = Depends(require_ability("manage_users")),
 ) -> list[User]:
     return db.query(User).order_by(User.email).all()
 


### PR DESCRIPTION
The Settings page is accessible by users with `manage_users` ability, but `GET /admin/users` required `is_admin`. This caused a 403 when a non-admin `manage_users` holder opened Settings — the page loaded but the user list API call failed.

**Fix:** Changed `list_users` from `get_current_admin` to `require_ability("manage_users")` so the frontend access check and backend authorization are consistent.