### PR TITLE
feat: replace hard-coded team/owner strings with database joins (closes #17)

### DIFF
--- a/backend/alembic/versions/0010_teams_table_and_drop_owner_name.py
+++ b/backend/alembic/versions/0010_teams_table_and_drop_owner_name.py
@@ -1,0 +1,79 @@
+"""Create teams table; replace project.team VARCHAR with team_id FK; drop owner_name
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-05-02
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Create teams table
+    op.create_table(
+        "teams",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("name", sa.String(128), unique=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+
+    # 2. Migrate existing team names into teams table
+    op.execute(
+        sa.text(
+            "INSERT INTO teams (name) "
+            "SELECT DISTINCT team FROM projects WHERE team IS NOT NULL AND team != '' "
+            "ON CONFLICT (name) DO NOTHING"
+        )
+    )
+
+    # 3. Add team_id column (nullable initially)
+    op.add_column("projects", sa.Column("team_id", UUID(as_uuid=True), nullable=True))
+
+    # 4. Update project.team_id to match the corresponding team
+    op.execute(
+        sa.text(
+            "UPDATE projects SET team_id = (SELECT id FROM teams WHERE teams.name = projects.team)"
+        )
+    )
+
+    # 5. Add FK constraint on team_id
+    op.create_foreign_key(
+        "fk_projects_team_id", "projects", "teams", ["team_id"], ["id"], ondelete="SET NULL"
+    )
+
+    # 6. Drop the old team column
+    op.drop_column("projects", "team")
+
+    # 7. Drop owner_name column (derived from user join now)
+    op.drop_column("projects", "owner_name")
+
+
+def downgrade() -> None:
+    op.add_column("projects", sa.Column("owner_name", sa.String(256), nullable=True))
+    op.add_column("projects", sa.Column("team", sa.String(128), nullable=True))
+
+    op.execute(
+        sa.text(
+            "UPDATE projects SET team = (SELECT name FROM teams WHERE teams.id = projects.team_id)"
+        )
+    )
+    # Restore owner_name from users join
+    op.execute(
+        sa.text(
+            "UPDATE projects SET owner_name = (SELECT full_name FROM users WHERE users.id = projects.owner_id)"
+        )
+    )
+
+    op.drop_constraint("fk_projects_team_id", "projects", type_="foreignkey")
+    op.drop_column("projects", "team_id")
+    op.drop_table("teams")

--- a/backend/src/formulation_ai/app.py
+++ b/backend/src/formulation_ai/app.py
@@ -10,6 +10,7 @@ from formulation_ai.routers import admin as admin_router
 from formulation_ai.routers import auth as auth_router
 from formulation_ai.routers import ingredients as ingredients_router
 from formulation_ai.routers import projects as projects_router
+from formulation_ai.routers import teams as teams_router
 
 
 def create_app() -> FastAPI:
@@ -31,6 +32,7 @@ def create_app() -> FastAPI:
     app.include_router(admin_router.router)
     app.include_router(ingredients_router.router)
     app.include_router(projects_router.router)
+    app.include_router(teams_router.router)
 
     @app.get("/health")
     def health():

--- a/backend/src/formulation_ai/models/__init__.py
+++ b/backend/src/formulation_ai/models/__init__.py
@@ -6,6 +6,7 @@ from formulation_ai.models.iteration import Iteration, IterationStatus
 from formulation_ai.models.output_property import FormulationProperty, OutputProperty, ProjectTarget
 from formulation_ai.models.portfolio import Portfolio
 from formulation_ai.models.project import Project, ProjectStatus
+from formulation_ai.models.team import Team
 from formulation_ai.models.user import User
 from formulation_ai.models.user_ability import UserAbility
 
@@ -17,6 +18,7 @@ __all__ = [
     "Portfolio",
     "Project",
     "ProjectStatus",
+    "Team",
     "Ingredient",
     "ProjectIngredient",
     "FormulationIngredient",

--- a/backend/src/formulation_ai/models/project.py
+++ b/backend/src/formulation_ai/models/project.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from formulation_ai.models.iteration import Iteration
     from formulation_ai.models.output_property import ProjectTarget
     from formulation_ai.models.portfolio import Portfolio
+    from formulation_ai.models.team import Team
     from formulation_ai.models.user import User
 
 
@@ -40,10 +41,11 @@ class Project(Base, TimestampMixin):
     owner_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL")
     )
-    owner_name: Mapped[str | None] = mapped_column(String(256))
     name: Mapped[str] = mapped_column(String(256), nullable=False)
     domain: Mapped[str | None] = mapped_column(String(128))
-    team: Mapped[str | None] = mapped_column(String(128))
+    team_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("teams.id", ondelete="SET NULL")
+    )
     status: Mapped[ProjectStatus] = mapped_column(
         SAEnum(ProjectStatus, native_enum=False, length=16),
         default=ProjectStatus.planning,
@@ -57,6 +59,7 @@ class Project(Base, TimestampMixin):
 
     portfolio: Mapped[Portfolio] = relationship(back_populates="projects")
     owner: Mapped[User | None] = relationship()
+    team: Mapped[Team | None] = relationship(back_populates="projects")
     ingredients: Mapped[list[ProjectIngredient]] = relationship(
         back_populates="project",
         cascade="all, delete-orphan",

--- a/backend/src/formulation_ai/models/team.py
+++ b/backend/src/formulation_ai/models/team.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from formulation_ai.models.base import Base
+
+if TYPE_CHECKING:
+    from formulation_ai.models.project import Project
+
+
+class Team(Base):
+    __tablename__ = "teams"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    name: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    projects: Mapped[list[Project]] = relationship(
+        back_populates="team", lazy="select"
+    )

--- a/backend/src/formulation_ai/routers/projects.py
+++ b/backend/src/formulation_ai/routers/projects.py
@@ -23,6 +23,7 @@ from formulation_ai.models import (
     ProjectIngredient,
     ProjectStatus,
     ProjectTarget,
+    Team,
     User,
 )
 from formulation_ai.models.iteration import Iteration, IterationStatus
@@ -166,7 +167,8 @@ def _targets_met(
 def _owner_display(owner: User | None) -> str | None:
     if not owner:
         return None
-    return owner.full_name or owner.email
+    display = owner.full_name or owner.email
+    return display or None
 
 
 def _project_to_list_item(project: Project) -> ProjectListItem:
@@ -336,17 +338,26 @@ async def upload_project(
             return None
 
     def _parse_team_id(s: str) -> uuid.UUID | None:
-        try:
-            return uuid.UUID(s.strip()) if s.strip() else None
-        except ValueError:
+        stripped = s.strip()
+        if not stripped:
             return None
+        try:
+            return uuid.UUID(stripped)
+        except ValueError:
+            raise HTTPException(status_code=422, detail="Invalid team_id format") from None
+
+    parsed_team_id = _parse_team_id(team_id)
+
+    # Validate team exists if an ID was provided
+    if parsed_team_id is not None and not db.get(Team, parsed_team_id):
+        raise HTTPException(status_code=404, detail="Team not found")
 
     # Create project
     project = Project(
         portfolio_id=portfolio.id,
         owner_id=current_user.id,
         name=name.strip(),
-        team_id=_parse_team_id(team_id),
+        team_id=parsed_team_id,
         domain=domain.strip() or None,
         status=ProjectStatus.planning,
         started_at=_parse_date(started_at),

--- a/backend/src/formulation_ai/routers/projects.py
+++ b/backend/src/formulation_ai/routers/projects.py
@@ -163,6 +163,12 @@ def _targets_met(
     return count
 
 
+def _owner_display(owner: User | None) -> str | None:
+    if not owner:
+        return None
+    return owner.full_name or owner.email
+
+
 def _project_to_list_item(project: Project) -> ProjectListItem:
     iterations_sorted = sorted(project.iterations, key=lambda i: i.n)
     current_iteration = max((i.n for i in iterations_sorted), default=0)
@@ -173,8 +179,8 @@ def _project_to_list_item(project: Project) -> ProjectListItem:
     return ProjectListItem(
         id=project.id,
         name=project.name,
-        team=project.team,
-        owner_name=project.owner_name,
+        team_name=project.team.name if project.team else None,
+        owner_name=_owner_display(project.owner),
         status=project.status,
         started_at=project.started_at,
         ends_at=project.ends_at,
@@ -252,6 +258,8 @@ def list_projects(
             selectinload(Project.targets).selectinload(ProjectTarget.output_property),
             selectinload(Project.formulations).selectinload(Formulation.properties),
             selectinload(Project.formulations).selectinload(Formulation.iteration),
+            selectinload(Project.team),
+            selectinload(Project.owner),
         )
         .order_by(Project.started_at.desc().nullslast())
     )
@@ -298,7 +306,7 @@ async def parse_upload(
 async def upload_project(
     file: UploadFile = File(...),
     name: str = Form(...),
-    team: str = Form(""),
+    team_id: str = Form(""),
     domain: str = Form(""),
     started_at: str = Form(""),
     ends_at: str = Form(""),
@@ -327,13 +335,18 @@ async def upload_project(
         except ValueError:
             return None
 
+    def _parse_team_id(s: str) -> uuid.UUID | None:
+        try:
+            return uuid.UUID(s.strip()) if s.strip() else None
+        except ValueError:
+            return None
+
     # Create project
     project = Project(
         portfolio_id=portfolio.id,
         owner_id=current_user.id,
-        owner_name=current_user.full_name or current_user.email,
         name=name.strip(),
-        team=team.strip() or None,
+        team_id=_parse_team_id(team_id),
         domain=domain.strip() or None,
         status=ProjectStatus.planning,
         started_at=_parse_date(started_at),
@@ -771,6 +784,8 @@ def get_project(
             .selectinload(Formulation.properties),
             selectinload(Project.formulations)
             .selectinload(Formulation.iteration),
+            selectinload(Project.team),
+            selectinload(Project.owner),
         )
     )
     project = db.scalar(stmt)
@@ -812,8 +827,8 @@ def get_project(
     return ProjectDetail(
         id=project.id,
         name=project.name,
-        team=project.team,
-        owner_name=project.owner_name,
+        team_name=project.team.name if project.team else None,
+        owner_name=_owner_display(project.owner),
         status=project.status,
         started_at=project.started_at,
         ends_at=project.ends_at,

--- a/backend/src/formulation_ai/routers/teams.py
+++ b/backend/src/formulation_ai/routers/teams.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
 from formulation_ai.auth import get_current_user, require_ability
@@ -22,7 +22,7 @@ class TeamOut(BaseModel):
 
 
 class TeamCreate(BaseModel):
-    name: str
+    name: str = Field(min_length=1, max_length=128)
 
 
 @router.get("", response_model=list[TeamOut])

--- a/backend/src/formulation_ai/routers/teams.py
+++ b/backend/src/formulation_ai/routers/teams.py
@@ -1,0 +1,49 @@
+"""Teams router — list and create teams."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session
+
+from formulation_ai.auth import get_current_user, require_ability
+from formulation_ai.db import get_db
+from formulation_ai.models import Team, User
+
+router = APIRouter(prefix="/teams", tags=["teams"])
+
+
+class TeamOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    name: str
+
+
+class TeamCreate(BaseModel):
+    name: str
+
+
+@router.get("", response_model=list[TeamOut])
+def list_teams(
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> list[Team]:
+    return db.query(Team).order_by(Team.name).all()
+
+
+@router.post("", response_model=TeamOut, status_code=status.HTTP_201_CREATED)
+def create_team(
+    payload: TeamCreate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_ability("manage_users")),
+) -> Team:
+    existing = db.query(Team).filter(Team.name == payload.name.strip()).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Team already exists")
+    team = Team(name=payload.name.strip())
+    db.add(team)
+    db.commit()
+    db.refresh(team)
+    return team

--- a/backend/src/formulation_ai/schemas/project.py
+++ b/backend/src/formulation_ai/schemas/project.py
@@ -51,7 +51,7 @@ class FormulationRead(BaseModel):
 class ProjectListItem(BaseModel):
     id: uuid.UUID
     name: str
-    team: str | None
+    team_name: str | None
     owner_name: str | None
     status: str
     started_at: date | None

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -15,7 +15,7 @@ import type { PortfolioProject } from '@/data/types'
 interface ApiProjectListItem {
   id: string
   name: string
-  team: string | null
+  team_name: string | null
   owner_name: string | null
   status: string
   started_at: string | null
@@ -39,7 +39,7 @@ export function PortfolioPage() {
           data.map((p) => ({
             id: p.id,
             name: p.name,
-            team: p.team ?? '',
+            team: p.team_name ?? '',
             owner: p.owner_name ?? '',
             status: p.status as PortfolioProject['status'],
             startedAt: p.started_at ?? '',

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -47,7 +47,7 @@ interface ApiIterationSummary {
 interface ApiProjectDetail {
   id: string
   name: string
-  team: string | null
+  team_name: string | null
   owner_name: string | null
   status: string
   started_at: string | null
@@ -98,7 +98,7 @@ function adaptProjectDetail(api: ApiProjectDetail): ProjectDetail {
   return {
     id: api.id,
     name: api.name,
-    team: api.team ?? '',
+    team: api.team_name ?? '',
     owner: api.owner_name ?? '',
     status: api.status as ProjectDetail['status'],
     domain: api.domain ?? '',

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -48,7 +48,7 @@ export function UploadPage() {
   useEffect(() => {
     apiFetch<{ id: string; name: string }[]>('/teams')
       .then(setTeams)
-      .catch(() => {})
+      .catch((e) => console.error('Failed to load teams:', e))
   }, [])
 
   async function parseFile(f: File) {

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   ArrowRight,
@@ -38,11 +38,18 @@ export function UploadPage() {
 
   // Project metadata
   const [projName, setProjName] = useState('')
-  const [projTeam, setProjTeam] = useState('')
+  const [projTeamId, setProjTeamId] = useState('')
+  const [teams, setTeams] = useState<{ id: string; name: string }[]>([])
   const [projDomain, setProjDomain] = useState('')
   const [projStartedAt, setProjStartedAt] = useState('')
   const [projEndsAt, setProjEndsAt] = useState('')
   const [projMaxIter, setProjMaxIter] = useState('6')
+
+  useEffect(() => {
+    apiFetch<{ id: string; name: string }[]>('/teams')
+      .then(setTeams)
+      .catch(() => {})
+  }, [])
 
   async function parseFile(f: File) {
     setFile(f)
@@ -90,7 +97,7 @@ export function UploadPage() {
       const fd = new FormData()
       fd.append('file', file)
       fd.append('name', projName.trim())
-      fd.append('team', projTeam.trim())
+      fd.append('team_id', projTeamId)
       fd.append('domain', projDomain.trim())
       fd.append('started_at', projStartedAt.trim())
       fd.append('ends_at', projEndsAt.trim())
@@ -147,12 +154,16 @@ export function UploadPage() {
               </div>
               <div>
                 <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Team</label>
-                <input
-                  value={projTeam}
-                  onChange={(e) => setProjTeam(e.target.value)}
-                  placeholder="e.g. Coatings"
+                <select
+                  value={projTeamId}
+                  onChange={(e) => setProjTeamId(e.target.value)}
                   className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
-                />
+                >
+                  <option value="">— None —</option>
+                  {teams.map((t) => (
+                    <option key={t.id} value={t.id}>{t.name}</option>
+                  ))}
+                </select>
               </div>
               <div>
                 <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Domain</label>


### PR DESCRIPTION
## Summary

Replaces the hard-coded `team` VARCHAR and denormalized `owner_name` on projects with proper database foreign key relationships.

### Changes

**Backend:**
- **New `teams` table** — `Team` model with id/name, `GET /teams` and `POST /teams` endpoints
- **`project.team`** → `project.team_id` FK to `teams.id`, with `team` relationship
- **Dropped `project.owner_name`** — now derived from `project.owner` (User) relationship
- **Migration 0010** — creates teams table, migrates existing team names, drops old columns
- **Eager loading** — `selectinload(Project.team)` and `selectinload(Project.owner)` in both list and detail queries
- **Upload endpoint** — accepts `team_id` (UUID) instead of `team` (free text)

**Frontend:**
- **Team dropdown** on upload page — fetches teams from `GET /teams`, replaces free-text input
- **API types** — maps `team_name` from API response
- Portfolio and project detail pages display team/owner from database joins

Closes #17