### PR TITLE
feat: add timestamps to iterations (closes #11)

### DIFF
--- a/backend/src/formulation_ai/routers/projects.py
+++ b/backend/src/formulation_ai/routers/projects.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
 
 from formulation_ai.auth import get_current_user
@@ -197,6 +197,7 @@ def _project_to_list_item(project: Project) -> ProjectListItem:
                 best_objective=it.best_objective,
                 status=it.status,
                 note=it.note,
+                started_at=it.started_at,
             )
             for it in iterations_sorted
         ],
@@ -489,6 +490,7 @@ def run_iteration(
         project_id=project.id,
         n=next_n,
         status=IterationStatus.in_progress,
+        started_at=func.now(),
     )
     db.add(iteration)
     db.flush()
@@ -658,6 +660,7 @@ def log_results(
             project_id=project.id,
             n=body.iteration_n,
             status=IterationStatus.in_progress,
+            started_at=func.now(),
         )
         db.add(iteration)
         db.flush()
@@ -850,7 +853,7 @@ def get_project(
         targets_total=targets_total,
         flag_note=project.flag_note,
         iterations=[
-            IterationSummary(n=it.n, best_objective=it.best_objective, status=it.status, note=it.note)
+            IterationSummary(n=it.n, best_objective=it.best_objective, status=it.status, note=it.note, started_at=it.started_at)
             for it in iterations_sorted
         ],
         ingredients=[

--- a/backend/src/formulation_ai/schemas/project.py
+++ b/backend/src/formulation_ai/schemas/project.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date
+from datetime import date, datetime
 
 from pydantic import BaseModel, ConfigDict
 
@@ -13,6 +13,7 @@ class IterationSummary(BaseModel):
     best_objective: float | None
     status: str
     note: str | None = None
+    started_at: datetime | None = None
 
 
 class IngredientSpec(BaseModel):

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -41,6 +41,7 @@ interface ApiIterationSummary {
   n: number
   best_objective: number | null
   status: string
+  started_at: string | null
   note?: string | null
 }
 
@@ -121,7 +122,7 @@ function adaptProjectDetail(api: ApiProjectDetail): ProjectDetail {
     })),
     iterations: api.iterations.map((it) => ({
       n: it.n,
-      date: '',
+      date: it.started_at ? new Date(it.started_at).toLocaleDateString() : '',
       candidates: 0,
       bestObjective: it.best_objective ?? 0,
       status: adaptIterationStatus(it.status),
@@ -692,7 +693,10 @@ function IterationCard({
         <span className="text-xs font-semibold uppercase tracking-wider">I{iteration.n}</span>
         <Icon className="h-3.5 w-3.5" />
       </div>
-      <p className="mt-3 text-[10px] uppercase tracking-wider opacity-70">Best objective</p>
+      {iteration.date && (
+        <p className="mt-1 text-[10px] text-muted-foreground">{iteration.date}</p>
+      )}
+      <p className="mt-2 text-[10px] uppercase tracking-wider opacity-70">Best objective</p>
       <p className="text-xl font-semibold tabular-nums text-foreground">
         {iteration.bestObjective > 0 ? `${Math.round(iteration.bestObjective * 100)}%` : '—'}
       </p>


### PR DESCRIPTION
## Summary

Iterations now record when they start and display the date in the timeline.

### Changes
- **Backend:** Set `started_at` when creating iterations in both `run-iteration` and `log-results`
- **API:** Added `started_at` to `IterationSummary` schema
- **Frontend:** Display the date on `IterationCard` in the project detail timeline

Closes #11