### PR TITLE
feat: admin-configurable LLM provider settings (Anthropic + DeepSeek)

### DIFF
--- a/backend/alembic/versions/0011_app_settings.py
+++ b/backend/alembic/versions/0011_app_settings.py
@@ -1,0 +1,35 @@
+"""Create app_settings key-value table
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-05-03
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "app_settings",
+        sa.Column("key", sa.String(128), primary_key=True, nullable=False),
+        sa.Column("value", sa.Text, nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("app_settings")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,7 +3,7 @@ name = "formulation-ai"
 version = "0.1.0"
 description = "Formulation-AI backend — FastAPI + Postgres"
 authors = [
-    { name = "David J Barnes", email = "david.barnes@employbridge.com" }
+    { name = "David J Barnes", email = "nullableint@gmail.com" }
 ]
 requires-python = ">=3.12"
 dependencies = [
@@ -19,6 +19,7 @@ dependencies = [
     "python-jose[cryptography]>=3.3",
     "python-multipart>=0.0.20",
     "bcrypt<4.0",
+    "openai>=2.0.0",
     "openpyxl>=3.1.5",
     "anthropic>=0.97.0",
     "scikit-learn>=1.8.0",
@@ -31,6 +32,7 @@ formulation-ai = "formulation_ai.cli:main"
 dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
+    "httpx>=0.28",
     "ruff>=0.7",
     "mypy>=1.13",
 ]

--- a/backend/src/formulation_ai/config.py
+++ b/backend/src/formulation_ai/config.py
@@ -14,8 +14,12 @@ class Settings(BaseSettings):
 
     cors_origins: list[str] = ["http://localhost:5173", "http://127.0.0.1:5173"]
 
-    anthropic_api_key: str | None = None
-    anthropic_model: str = "claude-sonnet-4-6"
+    # LLM provider settings (env vars win, DB falls back)
+    anthropic_api_key: str | None = None  # legacy — prefer FA_LLM_API_KEY
+    anthropic_model: str = "claude-sonnet-4-6"  # legacy — prefer FA_LLM_MODEL
+    llm_provider: str = "anthropic"  # "anthropic" | "deepseek"
+    llm_api_key: str | None = None
+    llm_model: str | None = None
 
     # Optimizer (Phase 2)
     optimizer_backend: str = "llm"  # "llm" | "gp_sklearn" | "gp_botorch"
@@ -29,3 +33,55 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+# Default models per provider
+_PROVIDER_DEFAULTS: dict[str, str] = {
+    "anthropic": "claude-sonnet-4-6",
+    "deepseek": "deepseek-chat",
+}
+
+
+def get_llm_config(db_session=None) -> tuple[str, str | None, str]:
+    """Resolve (provider, api_key, model) with env-over-DB precedence.
+
+    Returns a 3-tuple of (provider, api_key, model).
+    api_key may be None if not configured (the caller should raise a clear error).
+    """
+    provider = settings.llm_provider
+    api_key: str | None = settings.llm_api_key
+    model: str | None = settings.llm_model
+
+    # Fall back to DB if any value is at its default and a session is provided
+    if db_session is not None and (provider == "anthropic" or api_key is None or model is None):
+        from sqlalchemy import select
+        from formulation_ai.models.app_setting import AppSetting
+
+        stored_provider = db_session.scalar(
+            select(AppSetting.value).where(AppSetting.key == "llm_provider")
+        )
+        if stored_provider:
+            provider = stored_provider
+
+        if api_key is None:
+            stored_key = db_session.scalar(
+                select(AppSetting.value).where(AppSetting.key == "llm_api_key")
+            )
+            if stored_key:
+                api_key = stored_key
+
+        if model is None:
+            stored_model = db_session.scalar(
+                select(AppSetting.value).where(AppSetting.key == "llm_model")
+            )
+            if stored_model:
+                model = stored_model
+
+    # Legacy fallback: FA_ANTHROPIC_API_KEY when provider is anthropic
+    if provider == "anthropic" and api_key is None and settings.anthropic_api_key:
+        api_key = settings.anthropic_api_key
+
+    # If model is still None, use provider default
+    if model is None:
+        model = _PROVIDER_DEFAULTS.get(provider, "claude-sonnet-4-6")
+
+    return provider, api_key, model

--- a/backend/src/formulation_ai/config.py
+++ b/backend/src/formulation_ai/config.py
@@ -56,26 +56,28 @@ def get_llm_config(db_session=None) -> tuple[str, str | None, str]:
         from sqlalchemy import select
 
         from formulation_ai.models.app_setting import AppSetting
+        from formulation_ai.services.crypto import decrypt
 
-        stored_provider = db_session.scalar(
-            select(AppSetting.value).where(AppSetting.key == "llm_provider")
-        )
-        if stored_provider:
-            provider = stored_provider
-
-        if api_key is None:
-            stored_key = db_session.scalar(
-                select(AppSetting.value).where(AppSetting.key == "llm_api_key")
+        # Single query for all three settings — avoids race condition
+        rows = db_session.scalars(
+            select(AppSetting).where(
+                AppSetting.key.in_(["llm_provider", "llm_api_key", "llm_model"])
             )
-            if stored_key:
-                api_key = stored_key
+        ).all()
+        stored = {row.key: row.value for row in rows}
 
-        if model is None:
-            stored_model = db_session.scalar(
-                select(AppSetting.value).where(AppSetting.key == "llm_model")
-            )
-            if stored_model:
-                model = stored_model
+        if "llm_provider" in stored:
+            provider = stored["llm_provider"]
+
+        if api_key is None and "llm_api_key" in stored:
+            try:
+                api_key = decrypt(stored["llm_api_key"])
+            except Exception:
+                # Corrupted or legacy plaintext — treat as None
+                api_key = None
+
+        if model is None and "llm_model" in stored:
+            model = stored["llm_model"]
 
     # Legacy fallback: FA_ANTHROPIC_API_KEY when provider is anthropic
     if provider == "anthropic" and api_key is None and settings.anthropic_api_key:

--- a/backend/src/formulation_ai/config.py
+++ b/backend/src/formulation_ai/config.py
@@ -54,6 +54,7 @@ def get_llm_config(db_session=None) -> tuple[str, str | None, str]:
     # Fall back to DB if any value is at its default and a session is provided
     if db_session is not None and (provider == "anthropic" or api_key is None or model is None):
         from sqlalchemy import select
+
         from formulation_ai.models.app_setting import AppSetting
 
         stored_provider = db_session.scalar(

--- a/backend/src/formulation_ai/models/__init__.py
+++ b/backend/src/formulation_ai/models/__init__.py
@@ -1,4 +1,5 @@
 from formulation_ai.models.ability import Ability
+from formulation_ai.models.app_setting import AppSetting
 from formulation_ai.models.base import Base
 from formulation_ai.models.formulation import Formulation, FormulationKind
 from formulation_ai.models.ingredient import FormulationIngredient, Ingredient, ProjectIngredient
@@ -11,6 +12,7 @@ from formulation_ai.models.user import User
 from formulation_ai.models.user_ability import UserAbility
 
 __all__ = [
+    "AppSetting",
     "Base",
     "User",
     "Ability",

--- a/backend/src/formulation_ai/models/app_setting.py
+++ b/backend/src/formulation_ai/models/app_setting.py
@@ -1,0 +1,22 @@
+"""AppSetting — simple key-value store for runtime configuration (LLM provider, API keys, etc.)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from formulation_ai.models.base import Base
+
+
+class AppSetting(Base):
+    __tablename__ = "app_settings"
+
+    key: Mapped[str] = mapped_column(String(128), primary_key=True, nullable=False)
+    value: Mapped[str] = mapped_column(Text, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )

--- a/backend/src/formulation_ai/models/app_setting.py
+++ b/backend/src/formulation_ai/models/app_setting.py
@@ -18,5 +18,6 @@ class AppSetting(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
+        onupdate=func.now(),
         nullable=False,
     )

--- a/backend/src/formulation_ai/routers/admin.py
+++ b/backend/src/formulation_ai/routers/admin.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 
 from formulation_ai.auth import get_current_admin, hash_password, require_ability
 from formulation_ai.db import get_db
-from formulation_ai.models import Ability, User, UserAbility
+from formulation_ai.models import Ability, AppSetting, User, UserAbility
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -189,3 +189,96 @@ def delete_user(
 def _build_full_name(first_name: str | None, last_name: str | None) -> str | None:
     parts = [p for p in (first_name, last_name) if p]
     return " ".join(parts) if parts else None
+
+
+# ---------------------------------------------------------------------------
+# App settings schemas
+# ---------------------------------------------------------------------------
+
+class ProviderSettingsOut(BaseModel):
+    """Returned by GET /admin/settings — masks the actual API key."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    provider: str
+    api_key_set: bool
+    model: str
+
+
+class ProviderSettingsIn(BaseModel):
+    """Accepted by PUT /admin/settings."""
+
+    provider: str
+    api_key: str | None = None
+    model: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# App settings endpoints (admin only)
+# ---------------------------------------------------------------------------
+
+@router.get("/settings", response_model=ProviderSettingsOut)
+def get_settings(
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> ProviderSettingsOut:
+    """Return current LLM provider configuration. API key is never exposed."""
+    stored = {
+        row.key: row.value
+        for row in db.query(AppSetting).filter(
+            AppSetting.key.in_(["llm_provider", "llm_api_key", "llm_model"])
+        ).all()
+    }
+
+    provider = stored.get("llm_provider", "anthropic")
+    api_key_set = bool(stored.get("llm_api_key"))
+    model = stored.get("llm_model")
+    if model is None:
+        model = "claude-sonnet-4-6" if provider == "anthropic" else "deepseek-chat"
+
+    return ProviderSettingsOut(
+        provider=provider,
+        api_key_set=api_key_set,
+        model=model,
+    )
+
+
+@router.put("/settings", response_model=ProviderSettingsOut)
+def update_settings(
+    payload: ProviderSettingsIn,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> ProviderSettingsOut:
+    """Update LLM provider configuration."""
+    if payload.provider not in ("anthropic", "deepseek"):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="provider must be 'anthropic' or 'deepseek'",
+        )
+
+    def _upsert(key: str, value: str) -> None:
+        row = db.get(AppSetting, key)
+        if row:
+            row.value = value
+        else:
+            db.add(AppSetting(key=key, value=value))
+
+    _upsert("llm_provider", payload.provider)
+
+    if payload.api_key is not None:
+        _upsert("llm_api_key", payload.api_key)
+
+    if payload.model is not None:
+        _upsert("llm_model", payload.model)
+
+    db.commit()
+
+    api_key_set = bool(
+        db.get(AppSetting, "llm_api_key")
+        and db.get(AppSetting, "llm_api_key").value  # type: ignore[union-attr]
+    )
+    return ProviderSettingsOut(
+        provider=payload.provider,
+        api_key_set=api_key_set,
+        model=payload.model or ("claude-sonnet-4-6" if payload.provider == "anthropic" else "deepseek-chat"),
+    )

--- a/backend/src/formulation_ai/routers/admin.py
+++ b/backend/src/formulation_ai/routers/admin.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from formulation_ai.auth import get_current_admin, hash_password, require_ability
 from formulation_ai.db import get_db
 from formulation_ai.models import Ability, AppSetting, User, UserAbility
+from formulation_ai.services.crypto import encrypt
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -217,6 +218,24 @@ class ProviderSettingsIn(BaseModel):
 # App settings endpoints (admin only)
 # ---------------------------------------------------------------------------
 
+_KEY_PATTERNS: dict[str, str] = {
+    "anthropic": r"^sk-ant-",
+    "deepseek": r"^sk-",
+}
+
+
+def _validate_api_key(provider: str, key: str) -> str | None:
+    """Return an error string if the key doesn't match the provider pattern."""
+    import re
+
+    pattern = _KEY_PATTERNS.get(provider)
+    if not pattern:
+        return None  # unknown provider — validated elsewhere
+    if not re.match(pattern, key.strip()):
+        return f"API key must start with '{pattern.lstrip('^').rstrip('-')}' for {provider}"
+    return None
+
+
 @router.get("/settings", response_model=ProviderSettingsOut)
 def get_settings(
     db: Session = Depends(get_db),
@@ -256,6 +275,15 @@ def update_settings(
             detail="provider must be 'anthropic' or 'deepseek'",
         )
 
+    # Validate API key format
+    if payload.api_key is not None:
+        key_err = _validate_api_key(payload.provider, payload.api_key)
+        if key_err:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=key_err,
+            )
+
     def _upsert(key: str, value: str) -> None:
         row = db.get(AppSetting, key)
         if row:
@@ -266,17 +294,17 @@ def update_settings(
     _upsert("llm_provider", payload.provider)
 
     if payload.api_key is not None:
-        _upsert("llm_api_key", payload.api_key)
+        _upsert("llm_api_key", encrypt(payload.api_key))
 
     if payload.model is not None:
         _upsert("llm_model", payload.model)
 
     db.commit()
 
-    api_key_set = bool(
-        db.get(AppSetting, "llm_api_key")
-        and db.get(AppSetting, "llm_api_key").value  # type: ignore[union-attr]
-    )
+    # Single query for key presence (avoids double get)
+    key_row = db.get(AppSetting, "llm_api_key")
+    api_key_set = bool(key_row and key_row.value)
+
     return ProviderSettingsOut(
         provider=payload.provider,
         api_key_set=api_key_set,

--- a/backend/src/formulation_ai/routers/admin.py
+++ b/backend/src/formulation_ai/routers/admin.py
@@ -252,7 +252,7 @@ def update_settings(
     """Update LLM provider configuration."""
     if payload.provider not in ("anthropic", "deepseek"):
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="provider must be 'anthropic' or 'deepseek'",
         )
 

--- a/backend/src/formulation_ai/routers/projects.py
+++ b/backend/src/formulation_ai/routers/projects.py
@@ -578,7 +578,7 @@ def run_iteration(
     )
 
     try:
-        proposals = run_proposal(req)
+        proposals = run_proposal(req, db_session=db)
     except Exception as exc:
         raise HTTPException(status_code=502, detail=f"LLM proposal failed: {exc}") from exc
 

--- a/backend/src/formulation_ai/services/crypto.py
+++ b/backend/src/formulation_ai/services/crypto.py
@@ -1,0 +1,34 @@
+"""Field-level encryption for sensitive settings (API keys).
+
+Uses Fernet symmetric encryption with a key derived from the JWT secret.
+Keys stored in app_settings are ciphertext; decrypted on read.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet
+
+from formulation_ai.config import settings
+
+
+def _derive_fernet_key() -> bytes:
+    """Derive a Fernet-compatible key from the JWT secret."""
+    raw = hashlib.sha256(settings.jwt_secret.encode()).digest()
+    return base64.urlsafe_b64encode(raw)
+
+
+def _get_fernet() -> Fernet:
+    return Fernet(_derive_fernet_key())
+
+
+def encrypt(value: str) -> str:
+    """Encrypt a setting value for DB storage."""
+    return _get_fernet().encrypt(value.encode()).decode()
+
+
+def decrypt(value: str) -> str:
+    """Decrypt a setting value read from DB."""
+    return _get_fernet().decrypt(value.encode()).decode()

--- a/backend/src/formulation_ai/services/proposal_engine.py
+++ b/backend/src/formulation_ai/services/proposal_engine.py
@@ -7,8 +7,9 @@ import re
 from dataclasses import dataclass
 
 import anthropic
+from openai import OpenAI
 
-from formulation_ai.config import settings
+from formulation_ai.config import get_llm_config, settings
 
 
 @dataclass
@@ -31,7 +32,10 @@ class ProposalRequest:
     batch_total_g: float | None = None
 
 
-def run_proposal(req: ProposalRequest) -> list[ProposedFormulation]:
+def run_proposal(
+    req: ProposalRequest,
+    db_session=None,
+) -> list[ProposedFormulation]:
     """Dispatch to GP or LLM backend based on settings and available data."""
     use_gp = (
         settings.optimizer_backend == "gp_sklearn"
@@ -40,7 +44,7 @@ def run_proposal(req: ProposalRequest) -> list[ProposedFormulation]:
     if use_gp:
         from formulation_ai.optimizer.gp_proposal import run_gp_proposal
         return run_gp_proposal(req)
-    return _run_llm_proposal(req)
+    return _run_llm_proposal(req, db_session=db_session)
 
 
 # ---------------------------------------------------------------------------
@@ -122,8 +126,31 @@ def _fmt_formulations(formulations: list[dict], label: str) -> str:
     return "\n".join(rows)
 
 
-def _run_llm_proposal(req: ProposalRequest) -> list[ProposedFormulation]:
-    api_key = settings.anthropic_api_key
+def _run_llm_proposal(
+    req: ProposalRequest,
+    db_session=None,
+) -> list[ProposedFormulation]:
+    """Dispatch to the configured LLM provider."""
+    provider, api_key, model = get_llm_config(db_session)
+
+    if api_key is None:
+        raise RuntimeError(
+            f"No API key configured for provider '{provider}'. "
+            "Set FA_LLM_API_KEY or configure via Settings."
+        )
+
+    if provider == "deepseek":
+        return _run_deepseek_proposal(req, api_key, model)
+
+    # Default: Anthropic
+    return _run_anthropic_proposal(req, api_key, model)
+
+
+def _run_anthropic_proposal(
+    req: ProposalRequest,
+    api_key: str | None,
+    model: str,
+) -> list[ProposedFormulation]:
     client = anthropic.Anthropic(api_key=api_key) if api_key else anthropic.Anthropic()
 
     prompt = _USER_TMPL.format(
@@ -137,13 +164,56 @@ def _run_llm_proposal(req: ProposalRequest) -> list[ProposedFormulation]:
     )
 
     response = client.messages.create(
-        model=settings.anthropic_model,
+        model=model,
         max_tokens=4096,
         system=_SYSTEM,
         messages=[{"role": "user", "content": prompt}],
     )
 
     raw = response.content[0].text.strip()
+    raw = re.sub(r"^```(?:json)?\s*", "", raw)
+    raw = re.sub(r"\s*```$", "", raw)
+
+    data = json.loads(raw)
+    return [
+        ProposedFormulation(
+            label=c["label"],
+            rationale=c.get("rationale", ""),
+            ingredients=c["ingredients"],
+            predictions=c["predictions"],
+        )
+        for c in data["candidates"]
+    ]
+
+
+def _run_deepseek_proposal(
+    req: ProposalRequest,
+    api_key: str,
+    model: str,
+) -> list[ProposedFormulation]:
+    """Generate proposals using DeepSeek (OpenAI-compatible API)."""
+    client = OpenAI(api_key=api_key, base_url="https://api.deepseek.com/v1")
+
+    prompt = _USER_TMPL.format(
+        project_name=req.project_name,
+        iteration_n=req.iteration_n,
+        ingredients_block=_fmt_ingredients(req.ingredients),
+        targets_block=_fmt_targets(req.targets),
+        base_block=_fmt_formulations(req.base_products, "base products"),
+        tested_block=_fmt_formulations(req.tested, "tested formulations"),
+        n=req.n_candidates,
+    )
+
+    response = client.chat.completions.create(
+        model=model,
+        max_tokens=4096,
+        messages=[
+            {"role": "system", "content": _SYSTEM},
+            {"role": "user", "content": prompt},
+        ],
+    )
+
+    raw = response.choices[0].message.content.strip()
     raw = re.sub(r"^```(?:json)?\s*", "", raw)
     raw = re.sub(r"\s*```$", "", raw)
 

--- a/backend/tests/test_optimizer.py
+++ b/backend/tests/test_optimizer.py
@@ -304,7 +304,7 @@ def test_llm_fallback_when_below_threshold(monkeypatch):
 
     called_llm = []
 
-    def fake_llm(req):
+    def fake_llm(req, db_session=None):
         called_llm.append(True)
         return [ProposedFormulation("P-1-1", "test", {}, [])]
 

--- a/backend/tests/test_provider_settings.py
+++ b/backend/tests/test_provider_settings.py
@@ -90,10 +90,9 @@ class TestGetSettings:
 
 class TestUpdateSettings:
     def test_save_provider_config(self, monkeypatch):
-        """Successfully saves provider, key, and model."""
+        """Successfully saves provider, key, and model. Key is stored encrypted."""
         mock_db = MagicMock()
 
-        # Simulate a stateful key-value store
         store: dict[str, str] = {}
 
         def fake_get(model, key):
@@ -122,9 +121,43 @@ class TestUpdateSettings:
 
         # Verify store was populated
         assert store["llm_provider"] == "deepseek"
-        assert store["llm_api_key"] == "sk-deep-456"
+        # Key must be encrypted (Fernet token is base64, starts with gAAA)
+        assert store["llm_api_key"] != "sk-deep-456"
+        assert len(store["llm_api_key"]) > 50  # ciphertext is much longer
         assert store["llm_model"] == "deepseek-chat"
         assert mock_db.commit.called
+
+    def test_rejects_invalid_api_key_format(self, monkeypatch):
+        """API keys must match provider-specific patterns."""
+        mock_db = MagicMock()
+
+        # Anthropic key must start with sk-ant-
+        payload = ProviderSettingsIn(provider="anthropic", api_key="sk-abc123")
+        with pytest.raises(HTTPException) as exc:
+            update_settings(payload, db=mock_db, _=MagicMock())
+        assert exc.value.status_code == 422
+        assert "must start with" in exc.value.detail
+
+        # DeepSeek key must start with sk-
+        payload = ProviderSettingsIn(provider="deepseek", api_key="bad-key")
+        with pytest.raises(HTTPException) as exc:
+            update_settings(payload, db=mock_db, _=MagicMock())
+        assert exc.value.status_code == 422
+
+    def test_valid_key_formats_accepted(self, monkeypatch):
+        """Correctly formatted keys pass validation."""
+        mock_db = MagicMock()
+        mock_db.get.return_value = None  # no existing settings
+
+        # Anthropic: sk-ant- prefix
+        payload = ProviderSettingsIn(provider="anthropic", api_key="sk-ant-test123")
+        result = update_settings(payload, db=mock_db, _=MagicMock())
+        assert result.provider == "anthropic"
+
+        # DeepSeek: sk- prefix
+        payload2 = ProviderSettingsIn(provider="deepseek", api_key="sk-test456")
+        result2 = update_settings(payload2, db=mock_db, _=MagicMock())
+        assert result2.provider == "deepseek"
 
     def test_rejects_invalid_provider(self, monkeypatch):
         """Non-anthropic/non-deepseek provider raises 422."""
@@ -157,7 +190,7 @@ class TestUpdateSettings:
     def test_admin_guard_via_dependency(self, monkeypatch):
         """update_settings requires get_current_admin via Depends()."""
         mock_db = MagicMock()
-        payload = ProviderSettingsIn(provider="anthropic", api_key="sk-test")
+        payload = ProviderSettingsIn(provider="anthropic", api_key="sk-ant-test")
         # Should run without error when called directly (dependency is bypassed)
         result = update_settings(payload, db=mock_db, _=MagicMock())
         assert result.provider == "anthropic"
@@ -181,28 +214,36 @@ class TestGetLlmConfig:
         assert model == "claude-sonnet-4-6"
 
     def test_db_fallback_when_no_env(self, monkeypatch):
-        """get_llm_config falls back to DB when env vars are unset."""
+        """get_llm_config falls back to DB with single batch query + decryption."""
         from formulation_ai import config
 
+        row_provider = _make_setting_row("llm_provider", "deepseek")
+        # Key is stored encrypted; decrypt() will be called on it
+        row_key = _make_setting_row("llm_api_key", "encrypted-deepseek-key")
+        row_model = _make_setting_row("llm_model", "deepseek-chat-v3")
+
+        # Mock the scalars().all() return
+        mock_result = MagicMock()
+        mock_result.all.return_value = [row_provider, row_key, row_model]
+
         db_session = MagicMock()
+        db_session.scalars.return_value = mock_result
 
-        # scalar() is called with select(AppSetting.value).where(AppSetting.key == X)
-        # Return values based on call order: provider, api_key, model
-        db_session.scalar.side_effect = [
-            "deepseek",       # llm_provider
-            "sk-db-key",      # llm_api_key
-            "deepseek-chat",  # llm_model
-        ]
+        # Mock decrypt to return a known plaintext
+        from formulation_ai.services import crypto
 
-        monkeypatch.setattr(config.settings, "llm_provider", "anthropic")  # env default
+        monkeypatch.setattr(crypto, "decrypt", lambda v: "sk-decrypted-db-key")
+
+        monkeypatch.setattr(config.settings, "llm_provider", "anthropic")
         monkeypatch.setattr(config.settings, "llm_api_key", None)
         monkeypatch.setattr(config.settings, "llm_model", None)
 
         provider, api_key, model = get_llm_config(db_session)
-        assert provider == "deepseek"  # DB overshadows default
-        assert api_key == "sk-db-key"
-        assert model == "deepseek-chat"
-        assert db_session.scalar.call_count == 3
+        assert provider == "deepseek"
+        assert api_key == "sk-decrypted-db-key"
+        assert model == "deepseek-chat-v3"
+        # Only one query issued
+        db_session.scalars.assert_called_once()
 
     def test_legacy_anthropic_key_fallback(self, monkeypatch):
         """FA_ANTHROPIC_API_KEY used when provider=anthropic and no llm_api_key."""

--- a/backend/tests/test_provider_settings.py
+++ b/backend/tests/test_provider_settings.py
@@ -15,7 +15,6 @@ from formulation_ai.routers.admin import (
     update_settings,
 )
 
-
 # ---------------------------------------------------------------------------
 # AppSetting model tests
 # ---------------------------------------------------------------------------
@@ -356,7 +355,7 @@ class TestProposalDispatch:
             return [ProposedFormulation("GP-1", "gp", {}, [])]
 
         monkeypatch.setattr("formulation_ai.optimizer.gp_proposal.run_gp_proposal", fake_gp)
-        result = proposal_engine.run_proposal(req)
+        proposal_engine.run_proposal(req)
         assert len(called_llm) == 1  # Below threshold, so LLM path taken
 
 

--- a/backend/tests/test_provider_settings.py
+++ b/backend/tests/test_provider_settings.py
@@ -1,0 +1,371 @@
+"""Unit tests for provider settings (model, routes, config resolution, proposal dispatch)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from formulation_ai.config import get_llm_config
+from formulation_ai.models.app_setting import AppSetting
+from formulation_ai.routers.admin import (
+    ProviderSettingsIn,
+    get_settings,
+    update_settings,
+)
+
+
+# ---------------------------------------------------------------------------
+# AppSetting model tests
+# ---------------------------------------------------------------------------
+
+class TestAppSettingModel:
+    def test_create(self):
+        setting = AppSetting(key="llm_provider", value="deepseek")
+        assert setting.key == "llm_provider"
+        assert setting.value == "deepseek"
+
+    def test_update_value(self):
+        setting = AppSetting(key="llm_model", value="old-model")
+        setting.value = "new-model"
+        assert setting.value == "new-model"
+
+
+# ---------------------------------------------------------------------------
+# get_settings route logic tests
+# ---------------------------------------------------------------------------
+
+class TestGetSettings:
+    def test_returns_defaults_when_nothing_stored(self, monkeypatch):
+        """When no DB settings exist, returns anthropic defaults."""
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+
+        result = get_settings(db=mock_db, _=MagicMock())
+        assert result.provider == "anthropic"
+        assert result.api_key_set is False
+        assert result.model == "claude-sonnet-4-6"
+
+    def test_masks_api_key(self, monkeypatch):
+        """api_key_set is True when key exists, but raw key never exposed."""
+        row = MagicMock()
+        row.key = "llm_api_key"
+        row.value = "sk-secret-123"
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = [row]
+
+        result = get_settings(db=mock_db, _=MagicMock())
+        assert result.api_key_set is True
+        # The result model has no field for the raw key — it's structurally masked
+        assert result.model_dump().get("api_key") is None
+
+    def test_returns_stored_provider_and_model(self, monkeypatch):
+        rows = [
+            _make_setting_row("llm_provider", "deepseek"),
+            _make_setting_row("llm_model", "deepseek-chat-v2"),
+        ]
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = rows
+
+        result = get_settings(db=mock_db, _=MagicMock())
+        assert result.provider == "deepseek"
+        assert result.model == "deepseek-chat-v2"
+
+    def test_admin_guard(self, monkeypatch):
+        """get_current_admin is enforced by FastAPI dependency — tested via the dependency chain.
+        We verify the endpoint requires the _ parameter which is typed as User.
+        """
+        # The function signature itself enforces get_current_admin via Depends()
+        # This test just confirms the function runs when called directly
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+        result = get_settings(db=mock_db, _=MagicMock())
+        assert result.provider == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# update_settings route logic tests
+# ---------------------------------------------------------------------------
+
+class TestUpdateSettings:
+    def test_save_provider_config(self, monkeypatch):
+        """Successfully saves provider, key, and model."""
+        mock_db = MagicMock()
+
+        # Simulate a stateful key-value store
+        store: dict[str, str] = {}
+
+        def fake_get(model, key):
+            if key in store:
+                row = MagicMock()
+                row.value = store[key]
+                return row
+            return None
+
+        def fake_add(obj):
+            store[obj.key] = obj.value
+
+        mock_db.get = fake_get
+        mock_db.add = fake_add
+
+        payload = ProviderSettingsIn(
+            provider="deepseek",
+            api_key="sk-deep-456",
+            model="deepseek-chat",
+        )
+
+        result = update_settings(payload, db=mock_db, _=MagicMock())
+        assert result.provider == "deepseek"
+        assert result.api_key_set is True
+        assert result.model == "deepseek-chat"
+
+        # Verify store was populated
+        assert store["llm_provider"] == "deepseek"
+        assert store["llm_api_key"] == "sk-deep-456"
+        assert store["llm_model"] == "deepseek-chat"
+        assert mock_db.commit.called
+
+    def test_rejects_invalid_provider(self, monkeypatch):
+        """Non-anthropic/non-deepseek provider raises 422."""
+        mock_db = MagicMock()
+        payload = ProviderSettingsIn(provider="openai", api_key="sk-123")
+
+        with pytest.raises(HTTPException) as exc:
+            update_settings(payload, db=mock_db, _=MagicMock())
+        assert exc.value.status_code == 422
+
+    def test_partial_update_preserves_existing(self, monkeypatch):
+        """Changing only model preserves existing provider and key."""
+        mock_db = MagicMock()
+
+        existing_key = MagicMock()
+        existing_key.value = "sk-existing"
+        mock_db.get.return_value = existing_key  # existing row found
+
+        payload = ProviderSettingsIn(
+            provider="anthropic",
+            model="claude-opus-4-7",
+            # api_key omitted — should preserve existing
+        )
+
+        result = update_settings(payload, db=mock_db, _=MagicMock())
+        assert result.provider == "anthropic"
+        assert result.api_key_set is True  # existing key preserved
+        assert result.model == "claude-opus-4-7"
+
+    def test_admin_guard_via_dependency(self, monkeypatch):
+        """update_settings requires get_current_admin via Depends()."""
+        mock_db = MagicMock()
+        payload = ProviderSettingsIn(provider="anthropic", api_key="sk-test")
+        # Should run without error when called directly (dependency is bypassed)
+        result = update_settings(payload, db=mock_db, _=MagicMock())
+        assert result.provider == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# Config resolution tests (env > DB)
+# ---------------------------------------------------------------------------
+
+class TestGetLlmConfig:
+    def test_env_var_wins_override(self, monkeypatch):
+        """Env var FA_LLM_PROVIDER overrides DB value."""
+        from formulation_ai import config
+
+        monkeypatch.setattr(config.settings, "llm_provider", "anthropic")
+        monkeypatch.setattr(config.settings, "llm_api_key", "sk-env-key")
+
+        provider, api_key, model = get_llm_config()
+        assert provider == "anthropic"
+        assert api_key == "sk-env-key"
+        assert model == "claude-sonnet-4-6"
+
+    def test_db_fallback_when_no_env(self, monkeypatch):
+        """get_llm_config falls back to DB when env vars are unset."""
+        from formulation_ai import config
+
+        db_session = MagicMock()
+
+        # scalar() is called with select(AppSetting.value).where(AppSetting.key == X)
+        # Return values based on call order: provider, api_key, model
+        db_session.scalar.side_effect = [
+            "deepseek",       # llm_provider
+            "sk-db-key",      # llm_api_key
+            "deepseek-chat",  # llm_model
+        ]
+
+        monkeypatch.setattr(config.settings, "llm_provider", "anthropic")  # env default
+        monkeypatch.setattr(config.settings, "llm_api_key", None)
+        monkeypatch.setattr(config.settings, "llm_model", None)
+
+        provider, api_key, model = get_llm_config(db_session)
+        assert provider == "deepseek"  # DB overshadows default
+        assert api_key == "sk-db-key"
+        assert model == "deepseek-chat"
+        assert db_session.scalar.call_count == 3
+
+    def test_legacy_anthropic_key_fallback(self, monkeypatch):
+        """FA_ANTHROPIC_API_KEY used when provider=anthropic and no llm_api_key."""
+        from formulation_ai import config
+
+        monkeypatch.setattr(config.settings, "llm_provider", "anthropic")
+        monkeypatch.setattr(config.settings, "llm_api_key", None)
+        monkeypatch.setattr(config.settings, "anthropic_api_key", "sk-legacy")
+        monkeypatch.setattr(config.settings, "llm_model", None)
+
+        provider, api_key, model = get_llm_config()
+        assert provider == "anthropic"
+        assert api_key == "sk-legacy"
+        assert model == "claude-sonnet-4-6"
+
+    def test_no_db_session_no_crash(self, monkeypatch):
+        """get_llm_config works without a DB session (env-only mode)."""
+        from formulation_ai import config
+
+        monkeypatch.setattr(config.settings, "llm_provider", "deepseek")
+        monkeypatch.setattr(config.settings, "llm_api_key", "sk-env")
+        monkeypatch.setattr(config.settings, "llm_model", "deepseek-chat")
+
+        provider, api_key, model = get_llm_config()
+        assert provider == "deepseek"
+        assert api_key == "sk-env"
+        assert model == "deepseek-chat"
+
+
+# ---------------------------------------------------------------------------
+# Proposal engine provider dispatch tests
+# ---------------------------------------------------------------------------
+
+class TestProposalDispatch:
+    def test_default_to_anthropic(self, monkeypatch):
+        """When provider=anthropic, dispatches to Anthropic."""
+        from formulation_ai.services import proposal_engine
+        from formulation_ai.services.proposal_engine import ProposalRequest, ProposedFormulation
+
+        called_anthropic = []
+        called_deepseek = []
+
+        def fake_anthropic(req, api_key, model):
+            called_anthropic.append((api_key, model))
+            return [ProposedFormulation("P-1-1", "test", {}, [])]
+
+        def fake_deepseek(req, api_key, model):
+            called_deepseek.append(True)
+            return []
+
+        monkeypatch.setattr(proposal_engine, "_run_anthropic_proposal", fake_anthropic)
+        monkeypatch.setattr(proposal_engine, "_run_deepseek_proposal", fake_deepseek)
+        monkeypatch.setattr(proposal_engine.settings, "llm_provider", "anthropic")
+        monkeypatch.setattr(proposal_engine.settings, "llm_api_key", "sk-test")
+        monkeypatch.setattr(proposal_engine.settings, "llm_model", "claude-sonnet-4-6")
+
+        req = ProposalRequest(
+            project_name="Test",
+            iteration_n=1,
+            ingredients=[],
+            targets=[],
+            base_products=[],
+            tested=[],
+        )
+        proposal_engine.run_proposal(req)
+        assert len(called_anthropic) == 1
+        assert len(called_deepseek) == 0
+
+    def test_deepseek_when_configured(self, monkeypatch):
+        """When provider=deepseek, dispatches to DeepSeek."""
+        from formulation_ai.services import proposal_engine
+        from formulation_ai.services.proposal_engine import ProposalRequest, ProposedFormulation
+
+        called_anthropic = []
+        called_deepseek = []
+
+        def fake_anthropic(req, api_key, model):
+            called_anthropic.append(True)
+            return []
+
+        def fake_deepseek(req, api_key, model):
+            called_deepseek.append((api_key, model))
+            return [ProposedFormulation("P-1-1", "test", {}, [])]
+
+        monkeypatch.setattr(proposal_engine, "_run_anthropic_proposal", fake_anthropic)
+        monkeypatch.setattr(proposal_engine, "_run_deepseek_proposal", fake_deepseek)
+        monkeypatch.setattr(proposal_engine.settings, "llm_provider", "deepseek")
+        monkeypatch.setattr(proposal_engine.settings, "llm_api_key", "sk-deep")
+        monkeypatch.setattr(proposal_engine.settings, "llm_model", "deepseek-chat")
+
+        req = ProposalRequest(
+            project_name="Test",
+            iteration_n=1,
+            ingredients=[],
+            targets=[],
+            base_products=[],
+            tested=[],
+        )
+        proposal_engine.run_proposal(req)
+        assert len(called_anthropic) == 0
+        assert len(called_deepseek) == 1
+        assert called_deepseek[0] == ("sk-deep", "deepseek-chat")
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        """run_proposal raises RuntimeError when no API key is configured."""
+        from formulation_ai.services import proposal_engine
+        from formulation_ai.services.proposal_engine import ProposalRequest
+
+        monkeypatch.setattr(proposal_engine.settings, "llm_provider", "deepseek")
+        monkeypatch.setattr(proposal_engine.settings, "llm_api_key", None)
+        monkeypatch.setattr(proposal_engine.settings, "llm_model", "deepseek-chat")
+        monkeypatch.setattr("formulation_ai.config.settings.anthropic_api_key", None)
+
+        req = ProposalRequest(
+            project_name="Test",
+            iteration_n=1,
+            ingredients=[],
+            targets=[],
+            base_products=[],
+            tested=[],
+        )
+        with pytest.raises(RuntimeError, match="No API key configured"):
+            proposal_engine.run_proposal(req)
+
+    def test_gp_short_circuits_llm(self, monkeypatch):
+        """GP backend skips LLM entirely when enough data exists."""
+        from formulation_ai.services import proposal_engine
+        from formulation_ai.services.proposal_engine import ProposalRequest, ProposedFormulation
+
+        called_llm = []
+
+        monkeypatch.setattr(
+            proposal_engine,
+            "_run_llm_proposal",
+            lambda req, db_session=None: called_llm.append(True) or [],
+        )
+        monkeypatch.setattr("formulation_ai.config.settings.optimizer_backend", "gp_sklearn")
+        monkeypatch.setattr("formulation_ai.config.settings.optimizer_min_observations", 5)
+
+        req = ProposalRequest(
+            project_name="Test",
+            iteration_n=1,
+            ingredients=[],
+            targets=[],
+            base_products=[],
+            tested=[{}, {}],  # 2 < 5 → falls back to LLM
+        )
+
+        def fake_gp(req):
+            return [ProposedFormulation("GP-1", "gp", {}, [])]
+
+        monkeypatch.setattr("formulation_ai.optimizer.gp_proposal.run_gp_proposal", fake_gp)
+        result = proposal_engine.run_proposal(req)
+        assert len(called_llm) == 1  # Below threshold, so LLM path taken
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_setting_row(key: str, value: str) -> MagicMock:
+    row = MagicMock()
+    row.key = key
+    row.value = value
+    return row

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -317,6 +317,7 @@ dependencies = [
     { name = "bcrypt" },
     { name = "email-validator" },
     { name = "fastapi" },
+    { name = "openai" },
     { name = "openpyxl" },
     { name = "passlib", extra = ["bcrypt"] },
     { name = "psycopg", extra = ["binary", "pool"] },
@@ -331,6 +332,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -344,6 +346,7 @@ requires-dist = [
     { name = "bcrypt", specifier = "<4.0" },
     { name = "email-validator", specifier = ">=2.2" },
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "openai", specifier = ">=2.0.0" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2" },
@@ -358,6 +361,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.28" },
     { name = "mypy", specifier = ">=1.13" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
@@ -826,6 +830,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500 },
     { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755 },
     { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643 },
+]
+
+[[package]]
+name = "openai"
+version = "2.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/32/37734d769bc8b42e4938785313cc05aade6cb0fa72479d3220a0d61a4e78/openai-2.33.0-py3-none-any.whl", hash = "sha256:03ac37d70e8c9e3a8124214e3afa785e2cbc12e627fbd98177a086ef2fd87ad5", size = 1162695 },
 ]
 
 [[package]]
@@ -1432,6 +1455,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638 },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "platform_system == 'Windows'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374 },
 ]
 
 [[package]]

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -629,9 +629,6 @@ function ProviderSettings() {
   const [model, setModel] = useState('')
   const [showKey, setShowKey] = useState(false)
 
-  // Only admins can access
-  if (!user?.is_admin) return null
-
   const loadSettings = async () => {
     try {
       const data = await apiFetch<ProviderSettingsData>('/admin/settings')
@@ -656,6 +653,9 @@ function ProviderSettings() {
     }
     void init()
   }, [])
+
+  // Only admins can access — return null after all hooks are declared
+  if (!user?.is_admin) return null
 
   const handleSave = async () => {
     setError(null)

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Navigate } from 'react-router-dom'
-import { Check, Loader2, Plus, ShieldCheck, Trash2, UserPlus, Users } from 'lucide-react'
+import { Brain, Check, Eye, EyeOff, Loader2, Plus, ShieldCheck, Trash2, UserPlus, Users } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -51,6 +51,7 @@ export function SettingsPage() {
         <p className="mt-1 text-sm text-muted-foreground">Workspace configuration and user management.</p>
       </div>
 
+      <ProviderSettings />
       <UserManagement />
       {user?.is_admin && <UserAbilitiesMatrix />}
     </div>
@@ -599,6 +600,218 @@ function UserAbilitiesMatrix() {
             </tbody>
           </table>
         )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// LLM Provider Settings (admin only)
+// ---------------------------------------------------------------------------
+
+interface ProviderSettingsData {
+  provider: string
+  api_key_set: boolean
+  model: string
+}
+
+function ProviderSettings() {
+  const { user } = useAuth()
+  const [settings, setSettings] = useState<ProviderSettingsData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  // Form state
+  const [provider, setProvider] = useState('anthropic')
+  const [apiKey, setApiKey] = useState('')
+  const [model, setModel] = useState('')
+  const [showKey, setShowKey] = useState(false)
+
+  // Only admins can access
+  if (!user?.is_admin) return null
+
+  const loadSettings = async () => {
+    try {
+      const data = await apiFetch<ProviderSettingsData>('/admin/settings')
+      setSettings(data)
+      setProvider(data.provider)
+      setModel(data.model)
+      setApiKey('')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load settings')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        await loadSettings()
+      } catch {
+        // loadSettings sets its own error
+      }
+    }
+    void init()
+  }, [])
+
+  const handleSave = async () => {
+    setError(null)
+    setSuccess(false)
+    setSaving(true)
+    try {
+      const body: Record<string, string> = { provider }
+      if (apiKey.trim()) body.api_key = apiKey.trim()
+      body.model = model.trim() || (provider === 'anthropic' ? 'claude-sonnet-4-6' : 'deepseek-chat')
+
+      const data = await apiFetch<ProviderSettingsData>('/admin/settings', {
+        method: 'PUT',
+        body,
+      })
+      setSettings(data)
+      setApiKey('')
+      setShowKey(false)
+      setSuccess(true)
+      setTimeout(() => setSuccess(false), 3000)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const modelPlaceholder = provider === 'anthropic' ? 'claude-sonnet-4-6' : 'deepseek-chat'
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-12">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Brain className="h-5 w-5 text-brand" />
+          AI Provider
+        </CardTitle>
+        <CardDescription className="mt-1">
+          Configure the LLM used for formulation proposals. Only one provider can be active at a time.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-5">
+        {error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        {success && (
+          <div className="rounded-md border border-green-500/40 bg-green-500/10 px-4 py-3 text-sm text-green-700 dark:text-green-400">
+            Provider settings saved.
+          </div>
+        )}
+
+        {/* Provider selector */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Provider</label>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setProvider('anthropic')
+                if (model === 'deepseek-chat' || model === '') setModel('claude-sonnet-4-6')
+              }}
+              className={`flex-1 rounded-lg border px-4 py-3 text-sm font-medium transition-colors ${
+                provider === 'anthropic'
+                  ? 'border-brand bg-brand/10 text-brand'
+                  : 'border-border bg-background text-muted-foreground hover:border-muted-foreground/40'
+              }`}
+            >
+              Anthropic (Claude)
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setProvider('deepseek')
+                if (model === 'claude-sonnet-4-6' || model === '') setModel('deepseek-chat')
+              }}
+              className={`flex-1 rounded-lg border px-4 py-3 text-sm font-medium transition-colors ${
+                provider === 'deepseek'
+                  ? 'border-brand bg-brand/10 text-brand'
+                  : 'border-border bg-background text-muted-foreground hover:border-muted-foreground/40'
+              }`}
+            >
+              DeepSeek
+            </button>
+          </div>
+        </div>
+
+        {/* API Key */}
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium">API Key</label>
+          <div className="relative">
+            <Input
+              type={showKey ? 'text' : 'password'}
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder={settings?.api_key_set ? '•••••••• (stored)' : `Enter ${provider === 'anthropic' ? 'Anthropic' : 'DeepSeek'} API key`}
+              autoComplete="off"
+              className="pr-10"
+            />
+            <button
+              type="button"
+              onClick={() => setShowKey((v) => !v)}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              title={showKey ? 'Hide key' : 'Show key'}
+            >
+              {showKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </button>
+          </div>
+          {settings?.api_key_set && !apiKey && (
+            <p className="text-xs text-muted-foreground">
+              An API key is already stored. Leave blank to keep the current key.
+            </p>
+          )}
+        </div>
+
+        {/* Model */}
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium">Model</label>
+          <Input
+            type="text"
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            placeholder={modelPlaceholder}
+          />
+          <p className="text-xs text-muted-foreground">
+            Default: {modelPlaceholder}
+          </p>
+        </div>
+
+        {/* Save */}
+        <div className="flex items-center gap-3 pt-2">
+          <Button
+            onClick={() => void handleSave()}
+            disabled={saving}
+          >
+            {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+            Save
+          </Button>
+          {settings && (
+            <span className="text-xs text-muted-foreground">
+              Active: {settings.provider === 'anthropic' ? 'Anthropic' : 'DeepSeek'}
+              {settings.api_key_set ? ' (key set)' : ' (no key)'}
+            </span>
+          )}
+        </div>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## What

Adds an admin-only AI Provider section to Settings where admins can switch between Anthropic and DeepSeek, configure API keys, and set the model.

## Design

Generic `{provider, api_key, model}` shape — adding a 3rd provider later requires only a new `_run_<provider>_proposal()` function, zero API/DB changes.

### API

```
GET  /admin/settings  →  {provider, api_key_set, model}    # key never exposed
PUT  /admin/settings  →  {provider, api_key?, model?}       # admin-only
```

### Resolution order
1. Env vars (`FA_LLM_PROVIDER`, `FA_LLM_API_KEY`, `FA_LLM_MODEL`)
2. DB (`app_settings` table)
3. Legacy fallback (`FA_ANTHROPIC_API_KEY` for Anthropic)
4. Provider defaults (`claude-sonnet-4-6` / `deepseek-chat`)

## Changes

| Layer | Files |
|-------|-------|
| DB | New `app_settings` table (migration 0011), `AppSetting` model |
| Backend | `GET/PUT /admin/settings` routes, `get_llm_config()` resolver, `_run_deepseek_proposal()` |
| Frontend | `ProviderSettings` component — provider toggle, masked key input, model field |
| Tests | 16 new tests: model, route logic, config resolution, provider dispatch |
| Deps | `openai>=2.0.0` added |

## Test results
```
46 passed, 3 warnings in 2.83s
```