### PR TITLE
fix: rollback-safe deploy scripts + model dropdown fix

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -58,13 +58,30 @@ jobs:
             --timeout-seconds 600 \
             --parameters commands='[
               "set -e",
-              "docker image prune -af",
+              "echo === Pulling image ===",
               "aws ecr get-login-password --region '"$AWS_REGION"' | docker login --username AWS --password-stdin '"$ECR_REGISTRY"'",
               "docker pull '"$IMAGE"'",
+              "echo === Running migrations ===",
               "docker run --rm --network host --env-file '"$ENV_FILE"' '"$IMAGE"' alembic upgrade head",
-              "docker stop '"$CONTAINER_BACKEND"' || true && docker rm '"$CONTAINER_BACKEND"' || true",
+              "echo === Stopping old container ===",
+              "docker stop '"$CONTAINER_BACKEND"' 2>/dev/null || echo No old container",
+              "echo === Starting new container ===",
+              "docker rm '"$CONTAINER_BACKEND"' 2>/dev/null || true",
               "docker run -d --name '"$CONTAINER_BACKEND"' --restart unless-stopped --network host --env-file '"$ENV_FILE"' '"$IMAGE"' uvicorn formulation_ai.app:app --host 127.0.0.1 --port '"$BACKEND_PORT"' --proxy-headers --forwarded-allow-ips=*",
-              "for i in 1 2 3 4 5 6 7 8 9 10; do curl -sf http://127.0.0.1:'"$BACKEND_PORT"'/health && echo \"Health check passed\" && exit 0; echo \"Attempt $i failed, waiting 5s...\"; sleep 5; done; echo \"Health check failed\"; exit 1"
+              "echo === Health-checking ===",
+              "for i in 1 2 3 4 5 6 7 8 9 10; do curl -sf http://127.0.0.1:'"$BACKEND_PORT"'/health && echo Health OK && break; echo Attempt $i, waiting 5s...; sleep 5; done",
+              "if curl -sf http://127.0.0.1:'"$BACKEND_PORT"'/health; then",
+              "  echo === Deploy successful, cleaning up old images ===",
+              "  docker image prune -af",
+              "else",
+              "  echo === FAILED: rolling back to previous image ===",
+              "  docker logs --tail 30 '"$CONTAINER_BACKEND"' 2>/dev/null",
+              "  docker rm -f '"$CONTAINER_BACKEND"'",
+              "  docker run -d --name '"$CONTAINER_BACKEND"' --restart unless-stopped --network host --env-file '"$ENV_FILE"' 791342033319.dkr.ecr.us-west-2.amazonaws.com/formulation-ai-backend:latest uvicorn formulation_ai.app:app --host 127.0.0.1 --port '"$BACKEND_PORT"' --proxy-headers --forwarded-allow-ips=*",
+              "  echo === Rollback complete ===",
+              "  exit 1",
+              "fi",
+              "echo === Deploy complete ==="
             ]' \
             --query 'Command.CommandId' \
             --output text)

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -57,12 +57,28 @@ jobs:
             --timeout-seconds 300 \
             --parameters commands='[
               "set -e",
-              "docker image prune -af",
+              "echo === Pulling image ===",
               "aws ecr get-login-password --region '"$AWS_REGION"' | docker login --username AWS --password-stdin '"$ECR_REGISTRY"'",
               "docker pull '"$IMAGE"'",
-              "docker stop '"$CONTAINER_NGINX"' || true && docker rm '"$CONTAINER_NGINX"' || true",
+              "echo === Stopping old container ===",
+              "docker stop '"$CONTAINER_NGINX"' 2>/dev/null || echo No old container",
+              "echo === Starting new container ===",
+              "docker rm '"$CONTAINER_NGINX"' 2>/dev/null || true",
               "docker run -d --name '"$CONTAINER_NGINX"' --restart unless-stopped -p 127.0.0.1:'"$NGINX_PORT"':80 '"$IMAGE"'",
-              "for i in 1 2 3 4 5 6; do curl -sf http://127.0.0.1:'"$NGINX_PORT"'/ -o /dev/null && echo \"Nginx OK\" && exit 0; echo \"Attempt $i failed, waiting 5s...\"; sleep 5; done; echo \"Nginx health check failed\"; exit 1"
+              "echo === Health-checking ===",
+              "for i in 1 2 3 4 5 6; do curl -sf http://127.0.0.1:'"$NGINX_PORT"'/ -o /dev/null && echo Nginx OK && break; echo Attempt $i, waiting 5s...; sleep 5; done",
+              "if curl -sf http://127.0.0.1:'"$NGINX_PORT"'/ -o /dev/null; then",
+              "  echo === Deploy successful, cleaning up old images ===",
+              "  docker image prune -af",
+              "else",
+              "  echo === FAILED: rolling back to previous image ===",
+              "  docker logs --tail 30 '"$CONTAINER_NGINX"' 2>/dev/null",
+              "  docker rm -f '"$CONTAINER_NGINX"'",
+              "  docker run -d --name '"$CONTAINER_NGINX"' --restart unless-stopped -p 127.0.0.1:'"$NGINX_PORT"':80 791342033319.dkr.ecr.us-west-2.amazonaws.com/formulation-ai-nginx:latest",
+              "  echo === Rollback complete ===",
+              "  exit 1",
+              "fi",
+              "echo === Deploy complete ==="
             ]' \
             --query 'Command.CommandId' \
             --output text)


### PR DESCRIPTION
## Changes

### Rollback-safe deploy scripts
Both backend and frontend deploy workflows now:
1. Pull new image + run migrations (pre-step, no downtime)
2. Stop old container
3. Start new container
4. Health-check (up to 50s backend, 30s frontend)
5. **If healthy** → clean up old images, done
6. **If unhealthy** → log error, remove broken container, restart the `latest` known-good image, exit with error

This prevents the scenario where the deploy kills the old container but the new one fails to start (e.g., due to .env issues).

### Model dropdown fix
Ensures the model dropdown always shows a valid selection after API load.

## Previous PRs
- #36 (main feature) — merged
- #38 (model dropdown + deepseek-v4-pro) — merged